### PR TITLE
expose underlying reselect instance with cachedSelector.getMatchingSelector

### DIFF
--- a/__tests__/index.js
+++ b/__tests__/index.js
@@ -1,4 +1,5 @@
 /* eslint comma-dangle: 0 */
+import { createSelector } from 'reselect';
 import createCachedSelector from '../index';
 
 let memoizedFunction;
@@ -55,4 +56,19 @@ describe('createCachedSelector', () => {
 
     expect(memoizedFunction.mock.calls.length).toBe(1);
   });
+
+  it('should expose underlying reselect selector for a cache key with getMatchingSelector', () => {
+    const cachedSelector = createCachedSelector(
+      memoizedFunction,
+    )(
+      (arg1, arg2) => arg2   // Resolver
+    );
+
+    cachedSelector('foo', 1);
+    const reselectSelector = cachedSelector.getMatchingSelector('foo', 1);
+    const actualKeys = Object.keys(reselectSelector);
+    const expectedKeys = Object.keys(createSelector());
+
+    expect(actualKeys).toEqual(expectedKeys)
+  })
 });

--- a/index.js
+++ b/index.js
@@ -3,16 +3,25 @@ import { createSelector } from 'reselect';
 export default function createCachedSelector(...funcs) {
   const cache = {};
 
-  return (resolver, createSelectorInstance = createSelector) => (...args) => {
-    // Application receives this function
-    const cacheKey = resolver(...args);
+  return (resolver, createSelectorInstance = createSelector) => {
+    const selector = function(...args) {
+      // Application receives this function
+      const cacheKey = resolver(...args);
 
-    if (typeof cacheKey === 'string' || typeof cacheKey === 'number') {
-      if (cache.hasOwnProperty(cacheKey) === false) {
-        cache[cacheKey] = createSelectorInstance(...funcs);
+      if (typeof cacheKey === 'string' || typeof cacheKey === 'number') {
+        if (cache.hasOwnProperty(cacheKey) === false) {
+          cache[cacheKey] = createSelectorInstance(...funcs);
+        }
+        return cache[cacheKey](...args);
       }
-      return cache[cacheKey](...args);
-    }
-    return undefined;
-  };
+      return undefined;
+    };
+
+    selector.getMatchingSelector = (...args) => {
+      const cacheKey = resolver(...args);
+      return cache[cacheKey];
+    };
+
+    return selector;
+  }
 }


### PR DESCRIPTION
fixes #5 

@toomuchdesign 

let me know what you think -- i wasn't sure about what to call the new function