### PR TITLE
add resultFunc

### DIFF
--- a/__tests__/index.js
+++ b/__tests__/index.js
@@ -118,4 +118,14 @@ describe('createCachedSelector', () => {
     expect(firstSelectorActual).toBe(undefined);
     expect(secondSelectorActual).not.toBe(undefined);
   })
+
+  it('resultFunc', () => {
+    const cachedSelector = createCachedSelector(
+      jest.fn(),
+      memoizedFunction
+    )(
+      (arg1, arg2) => arg2
+    );
+    expect(cachedSelector.resultFunc).toBe(memoizedFunction);
+  })
 });

--- a/index.js
+++ b/index.js
@@ -34,6 +34,8 @@ export default function createCachedSelector(...funcs) {
       cache = {};
     };
 
+    selector.resultFunc = funcs[funcs.length -1];
+
     return selector;
   }
 }


### PR DESCRIPTION
This PR adds the `resultFunc` attribute to the returned selector. It's part of the original reselect API and I found myself needing it to write simpler selector tests.

You can see some examples of its use here:
https://github.com/reactjs/reselect#q-how-do-i-test-a-selector