### PR TITLE
fix getMatchingSelector typings

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -9,7 +9,7 @@ export type OutputSelector<S, R, C> = Selector<S, R> & {
 };
 
 export type OutputCachedSelector<S, R, C> = (resolver: Resolver<S>) => OutputSelector<S, R, C> & {
-  getMatchingSelector: (state: S, ...args: any[]) => Selector<S, R>;
+  getMatchingSelector: (state: S, ...args: any[]) => OutputSelector<S, R, C>;
   removeMatchingSelector: (state: S, ...args: any[]) => void;
   clearCache: () => void;
   resultFunc: C;
@@ -26,7 +26,7 @@ export type OutputParametricSelector<S, P, R, C> = ParametricSelector<S, P, R> &
 };
 
 export type OutputParametricCachedSelector<S, P, R, C> = (resolver: ParametricResolver<S, P>) => OutputParametricSelector<S, P, R, C> & {
-  getMatchingSelector: (state: S, ...args: any[]) => OutputParametricCachedSelector<S, P, R, any>;
+  getMatchingSelector: (state: S, ...args: any[]) => OutputParametricSelector<S, P, R, C>;
   removeMatchingSelector: (state: S, ...args: any[]) => void;
   clearCache: () => void;
   resultFunc: C;

--- a/typescript_test/test.ts
+++ b/typescript_test/test.ts
@@ -10,7 +10,18 @@ function testSelector() {
     (state: State) => state.foo,
   );
 
-  selector.getMatchingSelector({foo: 'bar'});
+  const parametricSelector = createCachedSelector(
+    (state: State, arg1: number) => state.foo,
+    (foo) => foo,
+  )(
+    (state: State, arg1: number) => state.foo,
+  );
+
+  const matchingSelectors = selector.getMatchingSelector({foo: 'bar'});
+  const resultFunc: (foo: string) => string = matchingSelectors.resultFunc;
+  const matchingParametricSelectors = selector.getMatchingSelector({foo: 'bar'});
+  const parametricResultFunc: (foo: string) => string = matchingParametricSelectors.resultFunc;
+
   selector.removeMatchingSelector({foo: 'bar'});
   selector.clearCache();
   const res = selector.resultFunc('test');


### PR DESCRIPTION
These are some corrections to https://github.com/toomuchdesign/re-reselect/pull/16:
- Use `OutputParametricSelector` rather than `OutputParametricCachedSelector`
- Use generic argument `C` rather than `any`
- Add tests