### PR TITLE
Add options object as last argument

### DIFF
--- a/__tests__/index.js
+++ b/__tests__/index.js
@@ -128,4 +128,30 @@ describe('createCachedSelector', () => {
     );
     expect(cachedSelector.resultFunc).toBe(resultFunc);
   })
+
+  it('Should accept a selectorCreator function as a 2° option', () => {
+    const cachedSelector = createCachedSelector(
+      () => {},
+      resultFunc
+    )(
+      (arg1, arg2) => arg2,
+      createSelector
+    );
+    const firstCall = cachedSelector('foo', 'bar');
+    expect(resultFunc.mock.calls.length).toBe(1);
+  })
+
+  it('Should accept an options object', () => {
+    const cachedSelector = createCachedSelector(
+      () => {},
+      resultFunc
+    )(
+      (arg1, arg2) => arg2,
+      {
+        selectorCreator: createSelector
+      }
+    );
+    const firstCall = cachedSelector('foo', 'bar');
+    expect(resultFunc.mock.calls.length).toBe(1);
+  })
 });

--- a/__tests__/index.js
+++ b/__tests__/index.js
@@ -8,13 +8,17 @@ beforeEach(() => {
   resultFunc = jest.fn();
 });
 
+function selectorWithMockedResultFunc() {
+  return createCachedSelector(
+    resultFunc,
+  )(
+    (arg1, arg2) => arg2,   // Resolver
+  );
+}
+
 describe('createCachedSelector', () => {
   it('Should use the same cached selector when resolver function returns the same string', () => {
-    const cachedSelector = createCachedSelector(
-      resultFunc,
-    )(
-      (arg1, arg2) => arg2,   // Resolver
-    );
+    const cachedSelector = selectorWithMockedResultFunc();
     const firstCall = cachedSelector('foo', 'bar');
     const secondCallWithSameResolver = cachedSelector('foo', 'bar');
 
@@ -22,11 +26,7 @@ describe('createCachedSelector', () => {
   });
 
   it('Should create 2 different selectors when resolver function returns different strings', () => {
-    const cachedSelector = createCachedSelector(
-      resultFunc,
-    )(
-      (arg1, arg2) => arg2,   // Resolver
-    );
+    const cachedSelector = selectorWithMockedResultFunc();
     const firstCallResult = cachedSelector('foo', 'bar');
     const secondCallWithDifferentResolver = cachedSelector('foo', 'moo');
 
@@ -46,11 +46,7 @@ describe('createCachedSelector', () => {
   });
 
   it('Should allow resolver function to return keys of type number', () => {
-    const cachedSelector = createCachedSelector(
-      resultFunc,
-    )(
-      (arg1, arg2) => arg2,   // Resolver
-    );
+    const cachedSelector = selectorWithMockedResultFunc();
     const firstCall = cachedSelector('foo', 1);
     const secondCallWithSameResolver = cachedSelector('foo', 1);
 
@@ -75,11 +71,7 @@ describe('createCachedSelector', () => {
   })
 
   it('Should return "undefined" when "getMatchingSelector" doesn\'t hit any cache entry', () => {
-    const cachedSelector = createCachedSelector(
-      resultFunc,
-    )(
-      (arg1, arg2) => arg2   // Resolver
-    );
+    const cachedSelector = selectorWithMockedResultFunc();
 
     const actual = cachedSelector.getMatchingSelector('foo', 1);
     const expected = undefined;
@@ -88,11 +80,7 @@ describe('createCachedSelector', () => {
   })
 
   it('Should reset the cache when calling "clearCache"', () => {
-    const cachedSelector = createCachedSelector(
-      resultFunc,
-    )(
-      (arg1, arg2) => arg2
-    );
+    const cachedSelector = selectorWithMockedResultFunc();
 
     cachedSelector('foo', 1) // add to cache
     cachedSelector.clearCache() // clear cache
@@ -102,11 +90,7 @@ describe('createCachedSelector', () => {
   })
 
   it('Should set the selected key to "undefined" when calling "removeMatchingSelector"', () => {
-    const cachedSelector = createCachedSelector(
-      resultFunc,
-    )(
-      (arg1, arg2) => arg2
-    );
+    const cachedSelector = selectorWithMockedResultFunc();
 
     cachedSelector('foo', 1); // add to cache
     cachedSelector('foo', 2); // add to cache
@@ -131,27 +115,30 @@ describe('createCachedSelector', () => {
 
   it('Should accept a selectorCreator function as a 2° option', () => {
     const cachedSelector = createCachedSelector(
-      () => {},
       resultFunc
     )(
       (arg1, arg2) => arg2,
-      createSelector
+      createSelector,
     );
-    const firstCall = cachedSelector('foo', 'bar');
+    expect(resultFunc.mock.calls.length).toBe(0);
+    cachedSelector('foo', 'bar');
+    cachedSelector('foo', 'bar');
     expect(resultFunc.mock.calls.length).toBe(1);
+
   })
 
   it('Should accept an options object', () => {
     const cachedSelector = createCachedSelector(
-      () => {},
       resultFunc
     )(
       (arg1, arg2) => arg2,
       {
-        selectorCreator: createSelector
+        selectorCreator: createSelector,
       }
     );
-    const firstCall = cachedSelector('foo', 'bar');
+    expect(resultFunc.mock.calls.length).toBe(0);
+    cachedSelector('foo', 'bar');
+    cachedSelector('foo', 'bar');
     expect(resultFunc.mock.calls.length).toBe(1);
   })
 });

--- a/index.d.ts
+++ b/index.d.ts
@@ -12,7 +12,7 @@ export type OutputSelector<S, R, C> = Selector<S, R> & {
   resetRecomputations: () => number;
 };
 
-export type OutputCachedSelector<S, R, C> = (resolver: Resolver<S>, createSelectorInstance?: CreateSelectorInstance) => OutputSelector<S, R, C> & {
+export type OutputCachedSelector<S, R, C> = (resolver: Resolver<S>, selectorCreator?: CreateSelectorInstance) => OutputSelector<S, R, C> & {
   getMatchingSelector: (state: S, ...args: any[]) => OutputSelector<S, R, C>;
   removeMatchingSelector: (state: S, ...args: any[]) => void;
   clearCache: () => void;
@@ -29,7 +29,7 @@ export type OutputParametricSelector<S, P, R, C> = ParametricSelector<S, P, R> &
   resetRecomputations: () => number;
 };
 
-export type OutputParametricCachedSelector<S, P, R, C> = (resolver: ParametricResolver<S, P>, createSelectorInstance?: CreateSelectorInstance) => OutputParametricSelector<S, P, R, C> & {
+export type OutputParametricCachedSelector<S, P, R, C> = (resolver: ParametricResolver<S, P>, selectorCreator?: CreateSelectorInstance) => OutputParametricSelector<S, P, R, C> & {
   getMatchingSelector: (state: S, props: P, ...args: any[]) => OutputParametricSelector<S, P, R, C>;
   removeMatchingSelector: (state: S, props: P, ...args: any[]) => void;
   clearCache: () => void;

--- a/index.js
+++ b/index.js
@@ -3,14 +3,14 @@ import { createSelector } from 'reselect';
 export default function createCachedSelector(...funcs) {
   let cache = {};
 
-  return (resolver, createSelectorInstance = createSelector) => {
+  return (resolver, selectorCreator = createSelector) => {
     const selector = function(...args) {
       // Application receives this function
       const cacheKey = resolver(...args);
 
       if (typeof cacheKey === 'string' || typeof cacheKey === 'number') {
         if (cache[cacheKey] === undefined) {
-          cache[cacheKey] = createSelectorInstance(...funcs);
+          cache[cacheKey] = selectorCreator(...funcs);
         }
         return cache[cacheKey](...args);
       }


### PR DESCRIPTION
This PR is intended as a working place for the changes discussed in #23.

New proposed API:
```
createCachedSelector(<...reselect arguments>)(keyFn, { selectorCreator, cacheSize }|selectorCreator|undefined);

```

## TODO's
- ~~Accept option object as last argument~~
- ~~Extract caching logic into separate `cacheObjectCreator`~~
- Update DOCS
- Update TS Typings
- Introduce 3 caching strategies:
    1. `lru-cache` Last Recently Used
    2. `fifo-cache` First In First Out
    3. ` flat-cache` or just cache as default cache
