### PR TITLE
docs(examples/join): typo `createCachedSelector`

### DIFF
--- a/examples/1-join-selectors.md
+++ b/examples/1-join-selectors.md
@@ -59,7 +59,7 @@ import createCachedSelector from re-reselect;
 
 const getWorldData = state => state.world;
 
-const getCountryData = createSelector(
+const getCountryData = createCachedSelector(
   getWorldData,
   (state, country) => country,
   (world, country) => extractData(world, country);


### PR DESCRIPTION
This example should have used `createCachedSelector` not `createSelector`.