### PR TITLE
Add cache property

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change log
 
+## 2.1.0
+
+### New Features
+
+* Expose `cache` property
+
 ## 2.0.0
 
 ### Breaking Changes

--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ const fooResultAgain = cachedSelector(state, 'foo');
   * [reReselectInstance`.removeMatchingSelector`](#rereselectinstanceremovematchingselectorselectorarguments)
   * [reReselectInstance`.clearCache`](#rereselectinstanceclearcache)
   * [reReselectInstance`.resultFunc`](#rereselectinstanceresultfunc)
+  * [reReselectInstance`.cache`](#rereselectinstancecache)
 
 ## Installation
 
@@ -390,6 +391,10 @@ Clear whole `reReselectInstance` cache.
 ### reReselectInstance`.resultFunc`
 
 Get `resultFunc` for easily [test composed selectors][reselect-test-selectors].
+
+### reReselectInstance`.cache`
+
+Get cacheObject instance being used by the selector (for advanced caching operations like [this](https://github.com/toomuchdesign/re-reselect/issues/40)).
 
 ## Todo's
 

--- a/src/__tests__/index.spec.js
+++ b/src/__tests__/index.spec.js
@@ -175,12 +175,23 @@ describe('createCachedSelector', () => {
     });
   });
 
-  describe('resultFunc', () => {
+  describe('resultFunc property', () => {
     it('Should point to provided result function', () => {
       const cachedSelector = createCachedSelector(() => {}, resultFunc)(
         (arg1, arg2) => arg2
       );
       expect(cachedSelector.resultFunc).toBe(resultFunc);
+    });
+  });
+
+  describe('cache property', () => {
+    it('Should point to currently used cacheObject', () => {
+      const currentCacheObject = new FlatObjectCache();
+      const cachedSelector = createCachedSelector(resultFunc)(arg1 => arg1, {
+        cacheObject: currentCacheObject,
+      });
+
+      expect(cachedSelector.cache).toBe(currentCacheObject);
     });
   });
 });

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -31,6 +31,7 @@ export type OutputCachedSelector<S, R, C> = (
   removeMatchingSelector: (state: S, ...args: any[]) => void;
   clearCache: () => void;
   resultFunc: C;
+  cache: ICacheObject;
 };
 
 export type ParametricSelector<S, P, R> = (
@@ -67,6 +68,7 @@ export type OutputParametricCachedSelector<S, P, R, C> = (
   removeMatchingSelector: (state: S, props: P, ...args: any[]) => void;
   clearCache: () => void;
   resultFunc: C;
+  cache: ICacheObject;
 };
 
 /* one selector */

--- a/src/index.js
+++ b/src/index.js
@@ -55,6 +55,8 @@ function createCachedSelector(...funcs) {
 
     selector.resultFunc = funcs[funcs.length - 1];
 
+    selector.cache = cache;
+
     return selector;
   };
 }

--- a/typescript_test/test.ts
+++ b/typescript_test/test.ts
@@ -25,6 +25,8 @@ function testSelector() {
 
   selector.clearCache();
 
+  selector.cache;
+
   // typings:expect-error
   selector({foo: 'bar'}, {prop: 'value'});
 
@@ -113,6 +115,8 @@ function testParametricSelector() {
   selector.removeMatchingSelector({foo: 'fizz'});
 
   selector.clearCache();
+
+  selector.cache;
 
   const selector2 = createCachedSelector(
     state => state.foo,


### PR DESCRIPTION
### What kind of change does this PR introduce?
Feature

### What is the current behaviour?
No `cacheObject` exposed by selectors. See #40. 

### What is the new behaviour?
Expose a `.cache` property pointing to the `cacheObject` being used by the selector.

### Does this PR introduce a breaking change? *(What changes might users need to make in their application due to this PR?)*
No

### Please check if the PR fulfills these requirements:
- [X] Tests for the changes have been added
- [X] Docs have been added / updated
