### PR TITLE
A doc fix

### DIFF
--- a/examples/2-avoid-selector-factories.md
+++ b/examples/2-avoid-selector-factories.md
@@ -1,6 +1,6 @@
 ## Avoid selector factories
 
-This example shows how `re-reselect` would solve the scenario described in [Reselect docs](https://github.com/reactjs/reselect#sharing-selectors-with-props-across-multiple-components): **_how to share a selector across multiple components while passing in props and retaining memoization?_**
+This example shows how `re-reselect` would solve the scenario described in [Reselect docs](https://github.com/reduxjs/reselect#sharing-selectors-with-props-across-multiple-component-instances): **_how to share a selector across multiple components while passing in props and retaining memoization?_**
 
 Using `re-reselect` you can directly declare `getVisibleTodos` selector. Since `re-reselect` handles selectors instantiation transparently, there is no need to declare a `makeGetVisibleTodos` factory.
 

--- a/examples/2-avoid-selector-factories.md
+++ b/examples/2-avoid-selector-factories.md
@@ -1,6 +1,6 @@
 ## Avoid selector factories
 
-This example shows how `re-reselect` would solve the scenario described in [Reselect docs](https://github.com/reduxjs/reselect#sharing-selectors-with-props-across-multiple-component-instances): **_how to share a selector across multiple components while passing in props and retaining memoization?_**
+This example shows how `re-reselect` would solve the scenario described in the [Reselect docs](https://github.com/reduxjs/reselect#sharing-selectors-with-props-across-multiple-component-instances): **_how to share a selector across multiple components while passing in props and retaining memoization?_**
 
 Using `re-reselect` you can directly declare `getVisibleTodos` selector. Since `re-reselect` handles selectors instantiation transparently, there is no need to declare a `makeGetVisibleTodos` factory.
 


### PR DESCRIPTION
### What kind of change does this PR introduce? _(Bug fix, feature, docs update, ...)_
docs update

### What is the current behaviour? _(You can also link to an open issue here)_
The link to the "reselect docs." in the docs section for "**How to share a selector across multiple components while passing in props and retaining memoization?**", is currently broken.  

### What is the new behaviour?
The link will work and take us to the section of the reselect docs titled "**Sharing Selectors with Props Across Multiple Component Instances**".

### Does this PR introduce a breaking change? _(What changes might users need to make in their application due to this PR?)_
No changes to re-reselect code.

### Other information:

### Please check if the PR fulfills these requirements:

* [ ] ~Tests for the changes have been added~ _*Not applicable._
* [x] Docs have been added / updated
