### PR TITLE
Fix cacheObject isValidCacheKey TS definition

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1534,33 +1534,35 @@ export interface ICacheObject {
   get(key: any): any;
   remove(key: any): void;
   clear(): void;
-  isValidCacheKey?(): boolean;
+  isValidCacheKey?(key: any): boolean;
 }
 
+type ObjectCacheKey = string | number;
+
 export class FlatObjectCache implements ICacheObject {
-  set(key: string | number, selectorFn: any): void;
-  get(key: string | number): any;
-  remove(key: string | number): void;
+  set(key: ObjectCacheKey, selectorFn: any): void;
+  get(key: ObjectCacheKey): any;
+  remove(key: ObjectCacheKey): void;
   clear(): void;
-  isValidCacheKey(): boolean;
+  isValidCacheKey(key: ObjectCacheKey): boolean;
 }
 
 export class FifoObjectCache implements ICacheObject {
   constructor(options: {cacheSize: number});
-  set(key: string | number, selectorFn: any): void;
-  get(key: string | number): any;
-  remove(key: string | number): void;
+  set(key: ObjectCacheKey, selectorFn: any): void;
+  get(key: ObjectCacheKey): any;
+  remove(key: ObjectCacheKey): void;
   clear(): void;
-  isValidCacheKey(): boolean;
+  isValidCacheKey(key: ObjectCacheKey): boolean;
 }
 
 export class LruObjectCache implements ICacheObject {
   constructor(options: {cacheSize: number});
-  set(key: string | number, selectorFn: any): void;
-  get(key: string | number): any;
-  remove(key: string | number): void;
+  set(key: ObjectCacheKey, selectorFn: any): void;
+  get(key: ObjectCacheKey): any;
+  remove(key: ObjectCacheKey): void;
   clear(): void;
-  isValidCacheKey(): boolean;
+  isValidCacheKey(key: ObjectCacheKey): boolean;
 }
 
 export class FlatMapCache implements ICacheObject {

--- a/typescript_test/cache.ts
+++ b/typescript_test/cache.ts
@@ -28,6 +28,8 @@ function testFlatObjectCache() {
   cacheObject.remove('foo');
   cacheObject.remove(1);
   cacheObject.clear();
+
+  cacheObject.isValidCacheKey(1);
 }
 
 function testFifoObjectCache() {
@@ -50,6 +52,8 @@ function testFifoObjectCache() {
   cacheObject.remove('foo');
   cacheObject.remove(1);
   cacheObject.clear();
+
+  cacheObject.isValidCacheKey(1);
 }
 
 function testLruObjectCache() {
@@ -72,6 +76,8 @@ function testLruObjectCache() {
   cacheObject.remove('foo');
   cacheObject.remove(1);
   cacheObject.clear();
+
+  cacheObject.isValidCacheKey(1);
 }
 
 function testFlatMapCache() {


### PR DESCRIPTION
### What kind of change does this PR introduce? _(Bug fix, feature, docs update, ...)_
TS definitions fix.

### What is the current behaviour? _(You can also link to an open issue here)_
TS definitions for `isValidCacheKey` method of CacheObject classes doesn't consider that the method accepts an argument.

### What is the new behaviour?
`isValidCacheKey` TS definition accepts `key` argument.

### Does this PR introduce a breaking change? _(What changes might users need to make in their application due to this PR?)_

No

### Other information:

### Please check if the PR fulfills these requirements:

* [X] Tests for the changes have been added
* [ ] Docs have been added / updated
