### PR TITLE
Add Redux-Views into the list of alternatives

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ const fooResultAgain = cachedSelector(state, 'foo');
       - [1- Declare a different selector for each different call](#1--declare-a-different-selector-for-each-different-call)
       - [2- Declare a `makeGetPieceOfData` selector factory as explained in Reselect docs](#2--declare-a-makegetpieceofdata-selector-factory-as-explained-in-reselect-docs)
       - [3- Wrap your `makeGetPieceOfData` selector factory into a memoizer function and call the returning memoized selector](#3--wrap-your-makegetpieceofdata-selector-factory-into-a-memoizer-function-and-call-the-returning-memoized-selector)
+      - [4- Use Redux-Views](#4--Use-Redux-Views)
   - [Examples](#examples)
   - [FAQ](#faq)
     - [How do I wrap my existing selector with re-reselect?](#how-do-i-wrap-my-existing-selector-with-re-reselect)
@@ -174,6 +175,10 @@ The solution suggested in [Reselect docs][reselect-sharing-selectors] is fine, b
 #### 3- Wrap your `makeGetPieceOfData` selector factory into a memoizer function and call the returning memoized selector
 
 This is what `re-reselect` actually does! :-) It's quite verbose (since has to be repeated for each selector), **that's why re-reselect is here**.
+
+#### 4- Use Redux-Views
+
+[Redux-Views](https://github.com/josepot/redux-views) solves the same problem, but uses a very different approach. Instead of enhancing `reselect`, `redux-views` is an all-in-one solution that tries to make the experience of working with shared selectors (almost) transparent for the user.
 
 ## Examples
 


### PR DESCRIPTION
### What kind of change does this PR introduce? _(Bug fix, feature, docs update, ...)_
Docs

Hi and thanks a lot for creating and maintaining `re-reselect`.

I have been a user of `re-reselect` for over a year now and I really appreciate the fact that `re-reselect` provides an elegant alternative to factory-selectors.

However, I have had the strong feeling that this is a problem that should be fixed in `reselect` itself for a long time now, and I have finally decided to create what I think that could be a [better alternative](https://github.com/josepot/redux-views). I discuss my reasons in detail in [this medium post](https://medium.com/@josepot/we-need-better-redux-selectors-457a1ed10732) (that I just published). If you are interested into knowing my motivations for creating another alternative, please read it. You may want to skip to [this section](https://medium.com/@josepot/we-need-better-redux-selectors-457a1ed10732#2caf), though.

I'm opening this PR for 2 different reasons:
- I think that users of `re-reselect` could be interested into knowing that there is another alternative.
- I would really appreciate to know what your thoughts are on `redux-views`.

Thanks!