### PR TITLE
Expose keySelector

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ const fooResultAgain = cachedSelector(state, 'foo');
     - [reReselectInstance`.resultFunc`](#rereselectinstanceresultfunc)
     - [reReselectInstance`.recomputations()`](#rereselectinstancerecomputations)
     - [reReselectInstance`.resetRecomputations()`](#rereselectinstanceresetrecomputations)
+    - [reReselectInstance`.keySelector`](#rereselectinstancekeyselector)
   - [About re-reselect](#about-re-reselect)
   - [Todo's](#todos)
   - [Contributors](#contributors)
@@ -432,6 +433,10 @@ Return the number of times the selector's result function has been recomputed.
 ### reReselectInstance`.resetRecomputations()`
 
 Reset `recomputations` count.
+
+### reReselectInstance`.keySelector`
+
+Get `keySelector` for utility compositions or testing.
 
 ## About re-reselect
 

--- a/src/__tests__/index.spec.js
+++ b/src/__tests__/index.spec.js
@@ -238,4 +238,14 @@ describe('createCachedSelector', () => {
       expect(cachedSelector.cache).toBe(currentCacheObject);
     });
   });
+
+  describe('"keySelector" property', () => {
+    it('Should point to provided keySelector', () => {
+      const keySelector = (arg1, arg2) => arg2;
+      const cachedSelector = createCachedSelector(() => {}, resultFuncMock)(
+        keySelector
+      );
+      expect(cachedSelector.keySelector).toBe(keySelector);
+    });
+  });
 });

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -52,6 +52,7 @@ export type OutputCachedSelector<S, R, C, D> = (
   removeMatchingSelector: (state: S, ...args: any[]) => void;
   clearCache: () => void;
   cache: ICacheObject;
+  keySelector: KeySelector<S>;
 };
 
 export type OutputParametricCachedSelector<S, P, R, C, D> = (
@@ -66,6 +67,7 @@ export type OutputParametricCachedSelector<S, P, R, C, D> = (
   removeMatchingSelector: (state: S, props: P, ...args: any[]) => void;
   clearCache: () => void;
   cache: ICacheObject;
+  keySelector: ParametricKeySelector<S, P>;
 };
 
 /*

--- a/src/index.js
+++ b/src/index.js
@@ -74,6 +74,8 @@ function createCachedSelector(...funcs) {
 
     selector.resetRecomputations = () => (recomputations = 0);
 
+    selector.keySelector = keySelector;
+
     return selector;
   };
 }

--- a/typescript_test/test.ts
+++ b/typescript_test/test.ts
@@ -1,5 +1,5 @@
 import {createSelectorCreator, defaultMemoize} from 'reselect';
-import createCachedSelector from '../src/index';
+import createCachedSelector, {KeySelector} from '../src/index';
 
 function testSelector() {
   type State = {foo: string};
@@ -25,6 +25,8 @@ function testSelector() {
     matchingSelectors.resultFunc;
 
   const resultFunc: (foo: string) => string = selector.resultFunc;
+
+  const keySelector: KeySelector<State> = selector.keySelector;
 
   // typings:expect-error
   selector.getMatchingSelector('foo');


### PR DESCRIPTION
### What kind of change does this PR introduce? _(Bug fix, feature, docs update, ...)_

feature

### What is the current behaviour? _(You can also link to an open issue here)_

reReselectInstance not expose key selector

### What is the new behaviour?

reReselectInstance expose key selector

### Does this PR introduce a breaking change? _(What changes might users need to make in their application due to this PR?)_

this PR does not introduce a breaking change

### Other information:
Key selector exposing usefull for utility compositions of selectors (like [createStructuredSelector](https://github.com/reduxjs/reselect#createstructuredselectorinputselectors-selectorcreator--createselector)) and testing

### Please check if the PR fulfills these requirements:

- [x] Tests for the changes have been added
- [x] Docs have been added / updated
