### PR TITLE
Add keySelectorCreator option

### DIFF
--- a/README.md
+++ b/README.md
@@ -368,7 +368,7 @@ A custom function receiving the same arguments as your selectors (and `inputSele
 
 `cacheKey` is **by default a `string` or `number`** but can be anything depending on the chosen cache strategy (see [`cacheObject` option](#optionscacheobject)).
 
-The `keySelector` idea comes from [Lodash's .memoize][lodash-memoize].
+The `keySelector` idea comes from [Lodash's .memoize resolver][lodash-memoize].
 
 ### options
 
@@ -385,6 +385,23 @@ Type: `function`<br />
 Default: `reselect`'s [`createSelector`][reselect-create-selector]
 
 An optional function describing a [custom version of createSelector][reselect-create-selector-creator].
+
+#### keySelectorCreator
+
+Type: `function`<br />
+Default: `undefined`
+
+An optional function with the following signature returning the [`keySelector`](#keyselector) used by the cached selector.
+
+```typescript
+export type keySelectorCreator = (selectorInputs: {
+  inputSelectors: InputSelector[];
+  resultFunc: ResultFunc;
+  keySelector: KeySelector;
+}) => KeySelector;
+```
+
+This allows to dynamically **generate `keySelectors` on runtime** based on provided `inputSelectors`/`resultFunc` and support [**key selectors composition**](https://github.com/toomuchdesign/re-reselect/pull/73).
 
 ### re-reselect selector instance
 

--- a/src/__tests__/createCachedSelector.spec.js
+++ b/src/__tests__/createCachedSelector.spec.js
@@ -114,24 +114,47 @@ describe('createCachedSelector', () => {
 
   it('Should throw an error when a function is provided as 2° argument', () => {
     expect(() => {
-      const cachedSelector = createCachedSelector(resultFuncMock)(() => {},
-      reselect.createSelector);
+      createCachedSelector(resultFuncMock)(() => {}, reselect.createSelector);
     }).toThrow(/Second argument "options" must be an object/);
   });
 
-  it('Should accept an options object', () => {
-    const cachedSelector = createCachedSelector(resultFuncMock)(
-      (arg1, arg2) => arg2,
-      {
-        cacheObject: new FlatObjectCache(),
-        selectorCreator: reselect.createSelector,
-      }
-    );
+  describe('options', () => {
+    it('Should accept cacheObject and selectorCreator options', () => {
+      const cachedSelector = createCachedSelector(resultFuncMock)(
+        (arg1, arg2) => arg2,
+        {
+          cacheObject: new FlatObjectCache(),
+          selectorCreator: reselect.createSelector,
+        }
+      );
 
-    expect(cachedSelector.recomputations()).toBe(0);
-    cachedSelector('foo', 'bar');
-    cachedSelector('foo', 'bar');
-    expect(cachedSelector.recomputations()).toBe(1);
+      expect(cachedSelector.recomputations()).toBe(0);
+      cachedSelector('foo', 'bar');
+      cachedSelector('foo', 'bar');
+      expect(cachedSelector.recomputations()).toBe(1);
+    });
+
+    it('Should accept selectorCreator option', () => {
+      const inputSelector = () => {};
+      const resultFunc = () => {};
+      const keySelector = () => {};
+      const generatedKeySelector = () => {};
+      const keySelectorCreatorMock = jest.fn(() => generatedKeySelector);
+
+      const cachedSelector = createCachedSelector(inputSelector, resultFunc)(
+        keySelector,
+        {
+          keySelectorCreator: keySelectorCreatorMock,
+        }
+      );
+
+      expect(keySelectorCreatorMock).toHaveBeenCalledWith({
+        inputSelectors: [inputSelector],
+        resultFunc: resultFunc,
+        keySelector: keySelector,
+      });
+      expect(cachedSelector.keySelector).toBe(generatedKeySelector);
+    });
   });
 
   describe('getMatchingSelector()', () => {

--- a/src/cache/__tests__/deprecated/FifoCacheObject.js
+++ b/src/cache/__tests__/deprecated/FifoCacheObject.js
@@ -1,7 +1,7 @@
 import {FifoCacheObject as CacheObject} from '../../../../src/index';
 
 describe('FifoCacheObject (deprecated)', () => {
-  it('Should return "FifoObjectCache" class', () => {
+  it('returns "FifoObjectCache" class', () => {
     expect(CacheObject.name).toBe('FifoObjectCache');
   });
 });

--- a/src/cache/__tests__/deprecated/FlatCacheObject.js
+++ b/src/cache/__tests__/deprecated/FlatCacheObject.js
@@ -1,7 +1,7 @@
 import {FlatCacheObject as CacheObject} from '../../../../src/index';
 
 describe('FlatCacheObject (deprecated)', () => {
-  it('Should return "FlatObjectCache" class', () => {
+  it('returns "FlatObjectCache" class', () => {
     expect(CacheObject.name).toBe('FlatObjectCache');
   });
 });

--- a/src/cache/__tests__/deprecated/LruCacheObject.js
+++ b/src/cache/__tests__/deprecated/LruCacheObject.js
@@ -1,7 +1,7 @@
 import {LruCacheObject as CacheObject} from '../../../../src/index';
 
 describe('LruCacheObject (deprecated)', () => {
-  it('Should return "LruMapCache" class', () => {
+  it('returns "LruMapCache" class', () => {
     expect(CacheObject.name).toBe('LruMapCache');
   });
 });

--- a/src/cache/__util__/testBasicBehavior.js
+++ b/src/cache/__util__/testBasicBehavior.js
@@ -2,7 +2,7 @@ import fillCacheWith from './fillCacheWith';
 
 function testBasicBehavior(CacheObject, options) {
   describe('Cache basic behavior', () => {
-    it('Should return cached value', () => {
+    it('returns cached value', () => {
       const cache = new CacheObject(options);
       const actual = () => {};
 
@@ -12,7 +12,7 @@ function testBasicBehavior(CacheObject, options) {
       expect(actual).toBe(expected);
     });
 
-    it('Should remove a single item', () => {
+    it('removes a single item', () => {
       const cache = new CacheObject(options);
       const entries = [1, 2, 3, 4, 5];
       fillCacheWith(cache, entries);
@@ -25,7 +25,7 @@ function testBasicBehavior(CacheObject, options) {
       });
     });
 
-    it('Should clear the cache', () => {
+    it('clears the cache', () => {
       const cache = new CacheObject(options);
       const entries = [1, 2, 3, 4, 5];
       fillCacheWith(cache, entries);

--- a/src/cache/__util__/testCacheSizeOptionValidation.js
+++ b/src/cache/__util__/testCacheSizeOptionValidation.js
@@ -1,12 +1,12 @@
 function testCacheSizeOptionValidation(CacheObject) {
   describe('cacheSize option validation', () => {
-    it('Should throw error if not defined', () => {
+    it('throws error if not defined', () => {
       expect(() => {
         const cache = new CacheObject();
       }).toThrow(/Missing/);
     });
 
-    it('Should throw error if not a positive integer', () => {
+    it('throws error if not a positive integer', () => {
       const wrongValues = [2.5, -12, 0];
 
       wrongValues.forEach(value => {
@@ -16,7 +16,7 @@ function testCacheSizeOptionValidation(CacheObject) {
       });
     });
 
-    it('Should not throw if a positive integer', () => {
+    it("doesn't throw if a positive integer", () => {
       expect(() => {
         const cache = new CacheObject({cacheSize: 22});
       }).not.toThrow();

--- a/src/cache/__util__/testFifoBehavior.js
+++ b/src/cache/__util__/testFifoBehavior.js
@@ -2,7 +2,7 @@ import fillCacheWith from './fillCacheWith';
 
 function testFifoBehavior(CacheObject) {
   describe('FIFO cache behavior', () => {
-    it('Should limit cache queue by removing the first added items', () => {
+    it('limits cache queue by removing the first added items', () => {
       const cache = new CacheObject({cacheSize: 5});
       const entries = [1, 2, 3, 4];
       const newEntries = [5, 6, 7];
@@ -17,7 +17,7 @@ function testFifoBehavior(CacheObject) {
       });
     });
 
-    it('Should mantain cache updated after removing extraneous entry', () => {
+    it('mantains cache updated after removing extraneous entry', () => {
       const cache = new CacheObject({cacheSize: 5});
       const entries = [1, 2, 3, 4, 5];
       fillCacheWith(cache, entries);

--- a/src/cache/__util__/testLruBehavior.js
+++ b/src/cache/__util__/testLruBehavior.js
@@ -2,7 +2,7 @@ import fillCacheWith from './fillCacheWith';
 
 function testLruBehavior(CacheObject) {
   describe('LRU cache behavior', () => {
-    it('Should remove an item and update cache ordering when another is added', () => {
+    it('removes an item and update cache ordering when another is added', () => {
       const cache = new CacheObject({cacheSize: 5});
       const entries = [1, 2, 3, 4, 5];
       fillCacheWith(cache, entries);
@@ -16,7 +16,7 @@ function testLruBehavior(CacheObject) {
       });
     });
 
-    it('Should limit cache queue by removing the least recently used item', () => {
+    it('limits cache queue by removing the least recently used item', () => {
       const cache = new CacheObject({cacheSize: 5});
 
       const entries = [0, 1, 2];

--- a/src/cache/__util__/testMapCacheKeyBehavior.js
+++ b/src/cache/__util__/testMapCacheKeyBehavior.js
@@ -3,13 +3,13 @@ import fillCacheWith from './fillCacheWith';
 function testMapCacheKeyBehavior(CacheObject, options) {
   describe('cacheKey', () => {
     describe('isValidCacheKey method', () => {
-      it('Should not exist', () => {
+      it("doesn't not exist", () => {
         const cache = new CacheObject(options);
         expect(cache.isValidCacheKey).toBe(undefined);
       });
     });
 
-    it('Any kind of value should work as cache key', () => {
+    it('any kind of value works as cache key', () => {
       const cache = new CacheObject(options);
       const entries = new Set([1, {}, 3, [], null]);
 

--- a/src/cache/__util__/testObjectCacheKeyBehavior.js
+++ b/src/cache/__util__/testObjectCacheKeyBehavior.js
@@ -1,6 +1,6 @@
 function testObjectCacheKeyBehavior(CacheObject, options) {
   describe('isValidCacheKey method', () => {
-    it('Should accept only numbers and string', () => {
+    it('accepts only numbers and string', () => {
       const cache = new CacheObject(options);
       const validValues = [1, 1.2, -5, 'foo', '12'];
       const invalidValues = [{}, [], null, undefined, new Map()];

--- a/src/createCachedSelector.js
+++ b/src/createCachedSelector.js
@@ -28,6 +28,14 @@ function createCachedSelector(...funcs) {
     const selectorCreator = options.selectorCreator || createSelector;
     const isValidCacheKey = cache.isValidCacheKey || defaultCacheKeyValidator;
 
+    if (options.keySelectorCreator) {
+      keySelector = options.keySelectorCreator({
+        inputSelectors: dependencies,
+        resultFunc,
+        keySelector,
+      });
+    }
+
     // Application receives this function
     const selector = function(...args) {
       const cacheKey = keySelector(...args);

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -34,20 +34,25 @@ export type OutputParametricSelector<S, P, R, C, D> = ParametricSelector<
 
 export type CreateSelectorInstance = typeof createSelector;
 
-type Options =
+type Options<S, C, D> =
   | {
       selectorCreator?: CreateSelectorInstance;
-      cacheObject: ICacheObject;
-    }
-  | {
-      selectorCreator: CreateSelectorInstance;
       cacheObject?: ICacheObject;
+      keySelectorCreator?: KeySelectorCreator<S, C, D>;
+    }
+  | CreateSelectorInstance;
+
+type ParametricOptions<S, P, C, D> =
+  | {
+      selectorCreator?: CreateSelectorInstance;
+      cacheObject?: ICacheObject;
+      keySelectorCreator?: ParametricKeySelectorCreator<S, P, C, D>;
     }
   | CreateSelectorInstance;
 
 export type OutputCachedSelector<S, R, C, D> = (
   keySelector: KeySelector<S>,
-  optionsOrSelectorCreator?: Options
+  optionsOrSelectorCreator?: Options<S, C, D>
 ) => OutputSelector<S, R, C, D> & {
   getMatchingSelector: (state: S, ...args: any[]) => OutputSelector<S, R, C, D>;
   removeMatchingSelector: (state: S, ...args: any[]) => void;
@@ -58,7 +63,7 @@ export type OutputCachedSelector<S, R, C, D> = (
 
 export type OutputParametricCachedSelector<S, P, R, C, D> = (
   keySelector: ParametricKeySelector<S, P>,
-  optionsOrSelectorCreator?: Options
+  optionsOrSelectorCreator?: ParametricOptions<S, P, C, D>
 ) => OutputParametricSelector<S, P, R, C, D> & {
   getMatchingSelector: (
     state: S,
@@ -4447,3 +4452,18 @@ export class LruMapCache implements ICacheObject {
   remove(key: any): void;
   clear(): void;
 }
+
+/*
+ * Key selector creators
+ */
+export type KeySelectorCreator<S, C, D> = (selectorInputs: {
+  inputSelectors: D;
+  resultFunc: C;
+  keySelector: KeySelector<S>;
+}) => KeySelector<S>;
+
+export type ParametricKeySelectorCreator<S, P, C, D> = (selectorInputs: {
+  inputSelectors: D;
+  resultFunc: C;
+  keySelector: ParametricKeySelector<S, P>;
+}) => ParametricKeySelector<S, P>;

--- a/typescript_test/createCachedSelector.ts
+++ b/typescript_test/createCachedSelector.ts
@@ -330,7 +330,7 @@ function testArrayArgument() {
   }
 }
 
-function testResolver() {
+function testKeySelector() {
   type State = {foo: string; obj: {bar: string}};
 
   const selector = createCachedSelector(
@@ -348,7 +348,7 @@ function testResolver() {
   )((state: never, obj) => obj);
 }
 
-function testCustomSelectorCreator() {
+function testSelectorCreatorOption() {
   type State = {foo: string};
 
   const selector1 = createCachedSelector(
@@ -368,4 +368,30 @@ function testCustomSelectorCreator() {
     (state: State) => state.foo,
     foo => foo
   )((state: State) => state.foo, (): void => {});
+}
+
+function testKeySelectorCreatorOption() {
+  type State = {foo: string};
+  const state = {foo: 'bar'};
+  const inputSelector = (state: State) => state.foo;
+  const resultFunc = (input: string) => input;
+  const keySelector = (state: State) => state.foo;
+
+  const selector = createCachedSelector(
+    inputSelector,
+    inputSelector,
+    resultFunc
+  )(keySelector, {
+    keySelectorCreator: ({inputSelectors, resultFunc, keySelector}) => {
+      const input1 = inputSelectors[0](state);
+      const input2 = inputSelectors[1](state);
+      // typings:expect-error
+      inputSelectors[2];
+
+      const result: string = resultFunc(input1, input2);
+      return keySelector;
+    },
+  });
+
+  const result: string = selector(state);
 }


### PR DESCRIPTION
### What kind of change does this PR introduce? _(Bug fix, feature, docs update, ...)_

feature

### What is the current behaviour? _(You can also link to an open issue here)_

#73

### What is the new behaviour?

Add `keySelectorCreator` option to provide an hook to dynamically generate `keySelectors` based on provided `inputSelectors`, `resultFunc` and `keySelector`.

### Does this PR introduce a breaking change? _(What changes might users need to make in their application due to this PR?)_

No

### Other information:

This is a partial release of a wider feature aiming to provide a way of composing automagically `cachedSelector`s. See: 

- #78 
- #73 

### Please check if the PR fulfills these requirements:

- [x] Tests for the changes have been added
- [x] Docs have been added / updated
