### PR TITLE
Introduce single argument signature

### DIFF
--- a/README.md
+++ b/README.md
@@ -329,15 +329,11 @@ import createCachedSelector from 're-reselect';
 createCachedSelector(
   // ...reselect's `createSelector` arguments
 )(
-  keySelector,
-  { options }
+  keySelector | { options }
 )
 ```
 
-Takes the same arguments as reselect's [`createSelector`][reselect-create-selector] and returns a new function which accepts **2 arguments**:
-
-- `keySelector`
-- `{ options }` _(optional)_
+Takes the same arguments as reselect's [`createSelector`][reselect-create-selector] and returns a new function which accepts a [`keySelector`](#keyselector) or an [`options`](#options) object.
 
 **Returns** a [selector instance][selector-instance-docs].
 
@@ -350,15 +346,11 @@ import { createStructuredCachedSelector } from 're-reselect';
 createStructuredCachedSelector(
   // ...reselect's `createStructuredSelector` arguments
 )(
-  keySelector,
-  { options }
+  keySelector | { options }
 )
 ```
 
-Takes the same arguments as reselect's [`createStructuredSelector`][reselect-create-structured-selector] and returns a new function which accepts **2 arguments**:
-
-- `keySelector`
-- `{ options }` _(optional)_
+Takes the same arguments as reselect's [`createStructuredSelector`][reselect-create-structured-selector] and returns a new function which accepts a [`keySelector`](#keyselector) or an [`options`](#options) object.
 
 **Returns** a [selector instance][selector-instance-docs].
 
@@ -372,19 +364,19 @@ The `keySelector` idea comes from [Lodash's .memoize resolver][lodash-memoize].
 
 ### options
 
+#### keySelector
+
+Type: `function`<br />
+Default: `undefined`
+
+The [`keySelector`](#keyselector) used by the cached selector.
+
 #### cacheObject
 
 Type: `object`<br />
 Default: [`FlatObjectCache`][cache-objects-docs]
 
 An optional custom **cache strategy object** to handle the caching behaviour. Read more about [re-reselect's custom cache here][cache-objects-docs].
-
-#### selectorCreator
-
-Type: `function`<br />
-Default: `reselect`'s [`createSelector`][reselect-create-selector]
-
-An optional function describing a [custom version of createSelector][reselect-create-selector-creator].
 
 #### keySelectorCreator
 
@@ -401,7 +393,14 @@ export type keySelectorCreator = (selectorInputs: {
 }) => KeySelector;
 ```
 
-This allows to dynamically **generate `keySelectors` on runtime** based on provided `inputSelectors`/`resultFunc` supporting [**key selectors composition**](https://github.com/toomuchdesign/re-reselect/pull/73).
+This allows to dynamically **generate `keySelectors` on runtime** based on provided `inputSelectors`/`resultFunc` supporting [**key selectors composition**](https://github.com/toomuchdesign/re-reselect/pull/73). It overrides any provided `keySelector`.
+
+#### selectorCreator
+
+Type: `function`<br />
+Default: `reselect`'s [`createSelector`][reselect-create-selector]
+
+An optional function describing a [custom version of createSelector][reselect-create-selector-creator].
 
 ### re-reselect selector instance
 

--- a/jest/__snapshots__/bundles-snapshot.test.js.snap
+++ b/jest/__snapshots__/bundles-snapshot.test.js.snap
@@ -54,14 +54,20 @@ exports[`Dist bundle is unchanged 1`] = `
       funcs[_key] = arguments[_key];
     }
 
-    return function (keySelector, options) {
-      if (options === void 0) {
-        options = {};
+    return function (polymorphicOptions, legacyOptions) {
+      // @NOTE Versions 0.x/1.x accepted \\"options\\" as a function
+      if (typeof legacyOptions === 'function') {
+        throw new Error('[re-reselect] Second argument \\"options\\" must be an object. Please use \\"options.selectorCreator\\" to provide a custom selectorCreator.');
       }
 
-      // @NOTE Versions 0.x/1.x accepted \\"options\\" as a function
-      if (typeof options === 'function') {
-        throw new Error('[re-reselect] Second argument \\"options\\" must be an object. Please use \\"options.selectorCreator\\" to provide a custom selectorCreator.');
+      var options = {};
+
+      if (typeof polymorphicOptions === 'function') {
+        Object.assign(options, legacyOptions, {
+          keySelector: polymorphicOptions
+        }); // @TODO add legacyOptions deprecation notice in next major release
+      } else {
+        Object.assign(options, polymorphicOptions);
       } // https://github.com/reduxjs/reselect/blob/v4.0.0/src/index.js#L54
 
 
@@ -80,16 +86,16 @@ exports[`Dist bundle is unchanged 1`] = `
       var isValidCacheKey = cache.isValidCacheKey || defaultCacheKeyValidator;
 
       if (options.keySelectorCreator) {
-        keySelector = options.keySelectorCreator({
+        options.keySelector = options.keySelectorCreator({
+          keySelector: options.keySelector,
           inputSelectors: dependencies,
-          resultFunc: resultFunc,
-          keySelector: keySelector
+          resultFunc: resultFunc
         });
       } // Application receives this function
 
 
       var selector = function selector() {
-        var cacheKey = keySelector.apply(void 0, arguments);
+        var cacheKey = options.keySelector.apply(options, arguments);
 
         if (isValidCacheKey(cacheKey)) {
           var cacheResponse = cache.get(cacheKey);
@@ -108,13 +114,13 @@ exports[`Dist bundle is unchanged 1`] = `
 
 
       selector.getMatchingSelector = function () {
-        var cacheKey = keySelector.apply(void 0, arguments); // @NOTE It might update cache hit count in LRU-like caches
+        var cacheKey = options.keySelector.apply(options, arguments); // @NOTE It might update cache hit count in LRU-like caches
 
         return cache.get(cacheKey);
       };
 
       selector.removeMatchingSelector = function () {
-        var cacheKey = keySelector.apply(void 0, arguments);
+        var cacheKey = options.keySelector.apply(options, arguments);
         cache.remove(cacheKey);
       };
 
@@ -134,7 +140,7 @@ exports[`Dist bundle is unchanged 1`] = `
         return recomputations = 0;
       };
 
-      selector.keySelector = keySelector;
+      selector.keySelector = options.keySelector;
       return selector;
     };
   }

--- a/src/cache/README.md
+++ b/src/cache/README.md
@@ -21,14 +21,12 @@ import createCachedSelector, {LruObjectCache, LruMapCache} from 're-reselect';
 
 createCachedSelector(
   // ...
-)(
+)({
   keySelector,
-  {
-    cacheObject: new LruObjectCache({cacheSize: 5}),
-    // or:
-    // cacheObject: new LruMapCache({cacheSize: 5}),
-  }
-);
+  cacheObject: new LruObjectCache({cacheSize: 5}),
+  // or:
+  // cacheObject: new LruMapCache({cacheSize: 5}),
+});
 ```
 
 **[*]ObjectCache** strategy objects treat `cacheKey` of type `number` like strings, since they are used as arguments of JS objects.

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -34,25 +34,23 @@ export type OutputParametricSelector<S, P, R, C, D> = ParametricSelector<
 
 export type CreateSelectorInstance = typeof createSelector;
 
-type Options<S, C, D> =
-  | {
-      selectorCreator?: CreateSelectorInstance;
-      cacheObject?: ICacheObject;
-      keySelectorCreator?: KeySelectorCreator<S, C, D>;
-    }
-  | CreateSelectorInstance;
+type Options<S, C, D> = {
+  selectorCreator?: CreateSelectorInstance;
+  cacheObject?: ICacheObject;
+  keySelector?: KeySelector<S>;
+  keySelectorCreator?: KeySelectorCreator<S, C, D>;
+};
 
-type ParametricOptions<S, P, C, D> =
-  | {
-      selectorCreator?: CreateSelectorInstance;
-      cacheObject?: ICacheObject;
-      keySelectorCreator?: ParametricKeySelectorCreator<S, P, C, D>;
-    }
-  | CreateSelectorInstance;
+type ParametricOptions<S, P, C, D> = {
+  selectorCreator?: CreateSelectorInstance;
+  cacheObject?: ICacheObject;
+  keySelector?: ParametricKeySelector<S, P>;
+  keySelectorCreator?: ParametricKeySelectorCreator<S, P, C, D>;
+};
 
 export type OutputCachedSelector<S, R, C, D> = (
-  keySelector: KeySelector<S>,
-  optionsOrSelectorCreator?: Options<S, C, D>
+  options: KeySelector<S> | Options<S, C, D>,
+  legacyOptions?: Options<S, C, D> | CreateSelectorInstance
 ) => OutputSelector<S, R, C, D> & {
   getMatchingSelector: (state: S, ...args: any[]) => OutputSelector<S, R, C, D>;
   removeMatchingSelector: (state: S, ...args: any[]) => void;
@@ -62,8 +60,8 @@ export type OutputCachedSelector<S, R, C, D> = (
 };
 
 export type OutputParametricCachedSelector<S, P, R, C, D> = (
-  keySelector: ParametricKeySelector<S, P>,
-  optionsOrSelectorCreator?: ParametricOptions<S, P, C, D>
+  options: ParametricKeySelector<S, P> | ParametricOptions<S, P, C, D>,
+  legacyOptions?: ParametricOptions<S, P, C, D> | CreateSelectorInstance
 ) => OutputParametricSelector<S, P, R, C, D> & {
   getMatchingSelector: (
     state: S,

--- a/typescript_test/cache.ts
+++ b/typescript_test/cache.ts
@@ -13,7 +13,8 @@ const combinerSelector = (foo: string) => foo;
 
 function testFlatObjectCache() {
   // Accepts this cache object as an option
-  createCachedSelector(fooSelector, combinerSelector)(fooSelector, {
+  createCachedSelector(fooSelector, combinerSelector)({
+    keySelector: fooSelector,
     cacheObject: new FlatObjectCache(),
   });
 
@@ -34,7 +35,8 @@ function testFlatObjectCache() {
 
 function testFifoObjectCache() {
   // Accepts this cache object as an option
-  createCachedSelector(fooSelector, combinerSelector)(fooSelector, {
+  createCachedSelector(fooSelector, combinerSelector)({
+    keySelector: fooSelector,
     cacheObject: new FifoObjectCache({cacheSize: 10}),
   });
 
@@ -58,7 +60,8 @@ function testFifoObjectCache() {
 
 function testLruObjectCache() {
   // Accepts this cache object as an option
-  createCachedSelector(fooSelector, combinerSelector)(fooSelector, {
+  createCachedSelector(fooSelector, combinerSelector)({
+    keySelector: fooSelector,
     cacheObject: new LruObjectCache({cacheSize: 10}),
   });
 
@@ -82,7 +85,8 @@ function testLruObjectCache() {
 
 function testFlatMapCache() {
   // Accepts this cache object as an option
-  createCachedSelector(fooSelector, combinerSelector)(fooSelector, {
+  createCachedSelector(fooSelector, combinerSelector)({
+    keySelector: fooSelector,
     cacheObject: new FlatMapCache(),
   });
 
@@ -102,7 +106,8 @@ function testFlatMapCache() {
 
 function testFifoMapCache() {
   // Accepts this cache object as an option
-  createCachedSelector(fooSelector, combinerSelector)(fooSelector, {
+  createCachedSelector(fooSelector, combinerSelector)({
+    keySelector: fooSelector,
     cacheObject: new FifoMapCache({cacheSize: 10}),
   });
 
@@ -125,7 +130,8 @@ function testFifoMapCache() {
 
 function testLruMapCache() {
   // Accepts this cache object as an option
-  createCachedSelector(fooSelector, combinerSelector)(fooSelector, {
+  createCachedSelector(fooSelector, combinerSelector)({
+    keySelector: fooSelector,
     cacheObject: new LruMapCache({cacheSize: 10}),
   });
 

--- a/typescript_test/createCachedSelector.ts
+++ b/typescript_test/createCachedSelector.ts
@@ -381,7 +381,8 @@ function testKeySelectorCreatorOption() {
     inputSelector,
     inputSelector,
     resultFunc
-  )(keySelector, {
+  )({
+    keySelector,
     keySelectorCreator: ({inputSelectors, resultFunc, keySelector}) => {
       const input1 = inputSelectors[0](state);
       const input2 = inputSelectors[1](state);


### PR DESCRIPTION
### What kind of change does this PR introduce? _(Bug fix, feature, docs update, ...)_

Feature + preparation for future breaking change

### What is the current behaviour? _(You can also link to an open issue here)_

The recent introduction of `keySelectorCreator` option brought out some limitation of the current `createCachedSelector` API:

```
createCachedSelector(...)(keySelector, options);
```
The relation existing between `keySelector` and `options.keySelectorCreator` was lost and the API become a bit chaotic.

```js
createCachedSelector(...)(
keySelector,
{
  keySelectorCreator: ({
    keySelector
  }) => {
    // Return a different keySelector
    return () => {}
  }
}
```
### What is the new behaviour?

This PR introduce the possibility of calling the return function of `createCachedSelector` with a **single option object**:

```js
createCachedSelector(...)(
{
  keySelector
  keySelectorCreator: ({
    keySelector
  }) => {
    // Return a different keySelector
    return () => {}
  }
}
```
Note that `options` object accepts a `keySelector` property.

The idea is to softly move the API to **accept only a single argument**:
- `keySelector` function for simple cases
- `option` object for any other advanced case

#### Breaking change soon

This is just a temporary additive solution. As a next step I'd like to get rid of some legacy API:

- Remove support for `createSelector` function as second argument
- Remove deprecated cache named exports
- Add a `console.warn` when `createCachedSelector` return function is called with 2 arguments.

### Does this PR introduce a breaking change? _(What changes might users need to make in their application due to this PR?)_

No

### Other information:

This PR was originated while elaborating over #78 and it's still very fresh.

It seems a pretty decent solution to me, but I'd really like to receive feedbacks especially from `re-reselect` honoured members @xsburg and @sgrishchenko! :)

### Please check if the PR fulfills these requirements:

- [x] Tests for the changes have been added
- [x] Docs have been added / updated
