### PR TITLE
[breaking-change] Remove old apis

### DIFF
--- a/jest/__snapshots__/bundles-snapshot.test.js.snap
+++ b/jest/__snapshots__/bundles-snapshot.test.js.snap
@@ -53,11 +53,6 @@ exports[`Dist bundle is unchanged 1`] = `
     }
 
     return function (polymorphicOptions, legacyOptions) {
-      // @NOTE Versions 0.x/1.x accepted \\"options\\" as a function
-      if (typeof legacyOptions === 'function') {
-        throw new Error('[re-reselect] Second argument \\"options\\" must be an object. Please use \\"options.selectorCreator\\" to provide a custom selectorCreator.');
-      }
-
       var options = {};
 
       if (typeof polymorphicOptions === 'function') {

--- a/jest/__snapshots__/bundles-snapshot.test.js.snap
+++ b/jest/__snapshots__/bundles-snapshot.test.js.snap
@@ -53,16 +53,13 @@ exports[`Dist bundle is unchanged 1`] = `
     }
 
     return function (polymorphicOptions, legacyOptions) {
-      var options = {};
+      if (legacyOptions) {
+        throw new Error('[re-reselect] \\"options\\" as second argument is not supported anymore. Please provide an option object as single argument.');
+      }
 
-      if (typeof polymorphicOptions === 'function') {
-        Object.assign(options, legacyOptions, {
-          keySelector: polymorphicOptions
-        }); // @TODO add legacyOptions deprecation notice in next major release
-      } else {
-        Object.assign(options, polymorphicOptions);
-      } // https://github.com/reduxjs/reselect/blob/v4.0.0/src/index.js#L54
-
+      var options = typeof polymorphicOptions === 'function' ? {
+        keySelector: polymorphicOptions
+      } : Object.assign({}, polymorphicOptions); // https://github.com/reduxjs/reselect/blob/v4.0.0/src/index.js#L54
 
       var recomputations = 0;
       var resultFunc = funcs.pop();

--- a/jest/__snapshots__/bundles-snapshot.test.js.snap
+++ b/jest/__snapshots__/bundles-snapshot.test.js.snap
@@ -373,13 +373,10 @@ exports[`Dist bundle is unchanged 1`] = `
     return LruMapCache;
   }();
 
-  exports.FifoCacheObject = FifoObjectCache;
   exports.FifoMapCache = FifoMapCache;
   exports.FifoObjectCache = FifoObjectCache;
-  exports.FlatCacheObject = FlatObjectCache;
   exports.FlatMapCache = FlatMapCache;
   exports.FlatObjectCache = FlatObjectCache;
-  exports.LruCacheObject = LruMapCache;
   exports.LruMapCache = LruMapCache;
   exports.LruObjectCache = LruObjectCache;
   exports.createStructuredCachedSelector = createStructuredCachedSelector;

--- a/src/__tests__/createCachedSelector.spec.js
+++ b/src/__tests__/createCachedSelector.spec.js
@@ -83,15 +83,6 @@ describe('createCachedSelector', () => {
         expect(cachedSelector.cache).toBeInstanceOf(LruObjectCache);
       });
     });
-
-    describe('as function as 2° argument', () => {
-      it('throws an error', () => {
-        expect(() => {
-          createCachedSelector(resultFuncMock)(() => {},
-          reselect.createSelector);
-        }).toThrow(/Second argument "options" must be an object/);
-      });
-    });
   });
 
   describe('created selector', () => {

--- a/src/__tests__/createCachedSelector.spec.js
+++ b/src/__tests__/createCachedSelector.spec.js
@@ -69,18 +69,11 @@ describe('createCachedSelector', () => {
       });
     });
 
-    describe('as function + object', () => {
-      it('accepts keySelector function + option object', () => {
-        const keySelectorMock = () => {};
-        const cachedSelector = createCachedSelector(resultFuncMock)(
-          keySelectorMock,
-          {
-            cacheObject: new LruObjectCache({cacheSize: 10}),
-          }
-        );
-
-        expect(cachedSelector.keySelector).toBe(keySelectorMock);
-        expect(cachedSelector.cache).toBeInstanceOf(LruObjectCache);
+    describe('as second argument', () => {
+      it('throws an error', () => {
+        expect(() => {
+          createCachedSelector(() => {})(() => {}, {});
+        }).toThrow(/"options" as second argument is not supported anymore/);
       });
     });
   });

--- a/src/cache/__tests__/deprecated/FifoCacheObject.js
+++ b/src/cache/__tests__/deprecated/FifoCacheObject.js
@@ -1,7 +1,0 @@
-import {FifoCacheObject as CacheObject} from '../../../../src/index';
-
-describe('FifoCacheObject (deprecated)', () => {
-  it('returns "FifoObjectCache" class', () => {
-    expect(CacheObject.name).toBe('FifoObjectCache');
-  });
-});

--- a/src/cache/__tests__/deprecated/FlatCacheObject.js
+++ b/src/cache/__tests__/deprecated/FlatCacheObject.js
@@ -1,7 +1,0 @@
-import {FlatCacheObject as CacheObject} from '../../../../src/index';
-
-describe('FlatCacheObject (deprecated)', () => {
-  it('returns "FlatObjectCache" class', () => {
-    expect(CacheObject.name).toBe('FlatObjectCache');
-  });
-});

--- a/src/cache/__tests__/deprecated/LruCacheObject.js
+++ b/src/cache/__tests__/deprecated/LruCacheObject.js
@@ -1,7 +1,0 @@
-import {LruCacheObject as CacheObject} from '../../../../src/index';
-
-describe('LruCacheObject (deprecated)', () => {
-  it('returns "LruMapCache" class', () => {
-    expect(CacheObject.name).toBe('LruMapCache');
-  });
-});

--- a/src/createCachedSelector.js
+++ b/src/createCachedSelector.js
@@ -6,13 +6,16 @@ const defaultCacheKeyValidator = () => true;
 
 function createCachedSelector(...funcs) {
   return (polymorphicOptions, legacyOptions) => {
-    const options = {};
-    if (typeof polymorphicOptions === 'function') {
-      Object.assign(options, legacyOptions, {keySelector: polymorphicOptions});
-      // @TODO add legacyOptions deprecation notice in next major release
-    } else {
-      Object.assign(options, polymorphicOptions);
+    if (legacyOptions) {
+      throw new Error(
+        '[re-reselect] "options" as second argument is not supported anymore. Please provide an option object as single argument.'
+      );
     }
+
+    const options =
+      typeof polymorphicOptions === 'function'
+        ? {keySelector: polymorphicOptions}
+        : Object.assign({}, polymorphicOptions);
 
     // https://github.com/reduxjs/reselect/blob/v4.0.0/src/index.js#L54
     let recomputations = 0;

--- a/src/createCachedSelector.js
+++ b/src/createCachedSelector.js
@@ -6,13 +6,6 @@ const defaultCacheKeyValidator = () => true;
 
 function createCachedSelector(...funcs) {
   return (polymorphicOptions, legacyOptions) => {
-    // @NOTE Versions 0.x/1.x accepted "options" as a function
-    if (typeof legacyOptions === 'function') {
-      throw new Error(
-        '[re-reselect] Second argument "options" must be an object. Please use "options.selectorCreator" to provide a custom selectorCreator.'
-      );
-    }
-
     const options = {};
     if (typeof polymorphicOptions === 'function') {
       Object.assign(options, legacyOptions, {keySelector: polymorphicOptions});

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -49,8 +49,7 @@ type ParametricOptions<S, P, C, D> = {
 };
 
 export type OutputCachedSelector<S, R, C, D> = (
-  options: KeySelector<S> | Options<S, C, D>,
-  legacyOptions?: Options<S, C, D>
+  options: KeySelector<S> | Options<S, C, D>
 ) => OutputSelector<S, R, C, D> & {
   getMatchingSelector: (state: S, ...args: any[]) => OutputSelector<S, R, C, D>;
   removeMatchingSelector: (state: S, ...args: any[]) => void;
@@ -60,8 +59,7 @@ export type OutputCachedSelector<S, R, C, D> = (
 };
 
 export type OutputParametricCachedSelector<S, P, R, C, D> = (
-  options: ParametricKeySelector<S, P> | ParametricOptions<S, P, C, D>,
-  legacyOptions?: ParametricOptions<S, P, C, D>
+  options: ParametricKeySelector<S, P> | ParametricOptions<S, P, C, D>
 ) => OutputParametricSelector<S, P, R, C, D> & {
   getMatchingSelector: (
     state: S,

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -50,7 +50,7 @@ type ParametricOptions<S, P, C, D> = {
 
 export type OutputCachedSelector<S, R, C, D> = (
   options: KeySelector<S> | Options<S, C, D>,
-  legacyOptions?: Options<S, C, D> | CreateSelectorInstance
+  legacyOptions?: Options<S, C, D>
 ) => OutputSelector<S, R, C, D> & {
   getMatchingSelector: (state: S, ...args: any[]) => OutputSelector<S, R, C, D>;
   removeMatchingSelector: (state: S, ...args: any[]) => void;
@@ -61,7 +61,7 @@ export type OutputCachedSelector<S, R, C, D> = (
 
 export type OutputParametricCachedSelector<S, P, R, C, D> = (
   options: ParametricKeySelector<S, P> | ParametricOptions<S, P, C, D>,
-  legacyOptions?: ParametricOptions<S, P, C, D> | CreateSelectorInstance
+  legacyOptions?: ParametricOptions<S, P, C, D>
 ) => OutputParametricSelector<S, P, R, C, D> & {
   getMatchingSelector: (
     state: S,

--- a/src/index.js
+++ b/src/index.js
@@ -12,9 +12,3 @@ export {default as LruObjectCache} from './cache/LruObjectCache';
 export {default as FlatMapCache} from './cache/FlatMapCache';
 export {default as FifoMapCache} from './cache/FifoMapCache';
 export {default as LruMapCache} from './cache/LruMapCache';
-
-// Deprecated cache objects exports
-// @TODO remove in next major release
-export {default as FlatCacheObject} from './cache/FlatObjectCache';
-export {default as FifoCacheObject} from './cache/FifoObjectCache';
-export {default as LruCacheObject} from './cache/LruMapCache';

--- a/typescript_test/createCachedSelector.ts
+++ b/typescript_test/createCachedSelector.ts
@@ -356,7 +356,7 @@ function testSelectorCreatorOption() {
   const selector1 = createCachedSelector(
     (state: State) => state.foo,
     foo => foo
-  )((state: State) => state.foo, createSelectorCreator(defaultMemoize));
+  )((state: State) => state.foo);
 
   const selector2 = createCachedSelector(
     (state: State) => state.foo,

--- a/typescript_test/createCachedSelector.ts
+++ b/typescript_test/createCachedSelector.ts
@@ -332,7 +332,7 @@ function testArrayArgument() {
   }
 }
 
-function testKeySelector() {
+function testKeySelectorOption() {
   type State = {foo: string; obj: {bar: string}};
 
   const selector = createCachedSelector(
@@ -347,32 +347,9 @@ function testKeySelector() {
   const selector2 = createCachedSelector(
     (state: State) => state.obj,
     obj => obj
-  )((state: State, obj) => obj);
-}
-
-function testSelectorCreatorOption() {
-  type State = {foo: string};
-
-  const selector1 = createCachedSelector(
-    (state: State) => state.foo,
-    foo => foo
-  )((state: State) => state.foo);
-
-  const selector2 = createCachedSelector(
-    (state: State) => state.foo,
-    foo => foo
-  )((state: State) => state.foo, {
-    selectorCreator: createSelectorCreator(defaultMemoize),
+  )({
+    keySelector: (state: State, obj) => obj,
   });
-
-  // typings:expect-error
-  const selectorFailing = createCachedSelector(
-    (state: State) => state.foo,
-    foo => foo
-  )(
-    (state: State) => state.foo,
-    (): void => {}
-  );
 }
 
 function testKeySelectorCreatorOption() {
@@ -400,4 +377,16 @@ function testKeySelectorCreatorOption() {
   });
 
   const result: string = selector(state);
+}
+
+function testSelectorCreatorOption() {
+  type State = {foo: string};
+
+  const selector2 = createCachedSelector(
+    (state: State) => state.foo,
+    foo => foo
+  )({
+    keySelector: (state: State) => state.foo,
+    selectorCreator: createSelectorCreator(defaultMemoize),
+  });
 }


### PR DESCRIPTION
### What kind of change does this PR introduce? _(Bug fix, feature, docs update, ...)_

Refactor

### What is the current behaviour? _(You can also link to an open issue here)_

Remove deprecated api's:

- Remove support for options as second argument
- Remove deprecated cache exports

### What is the new behaviour?

Support single argument API, only.

Throw when second argument is provided.

### Does this PR introduce a breaking change? _(What changes might users need to make in their application due to this PR?)_

Yes. Users providing `options` as second argument, should use the option object as single argument extended with a `keySelector` property.

### Other information:

### Please check if the PR fulfills these requirements:

- [X] Tests for the changes have been added
- [ ] Docs have been added / updated
