### PR TITLE
Auto infer structured selectors types

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   ],
   "scripts": {
     "test": "npm run test:typescript && jest ./src",
-    "test:typescript": "typings-tester --config typescript_test/tsconfig.json --dir typescript_test",
+    "test:typescript": "typings-tester --dir typescript_test",
     "test:bundles": "npm run test:bundles:snapshot && npm run test:bundles:unit",
     "test:bundles:unit": "jest ./src --config ./jest/es.config.js && jest ./src --config ./jest/lib.config.js && jest ./src --config ./jest/dist.config.js",
     "test:bundles:snapshot": "jest ./jest/bundles-snapshot.test.js",

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -4370,23 +4370,35 @@ export default function createCachedSelector<S, P, R, T>(
 /*
  * createStructuredCachedSelector
  */
-export function createStructuredCachedSelector<S, T>(
-  selectors: {[K in keyof T]: Selector<S, T[K]>}
+
+export function createStructuredCachedSelector<
+  T extends {[key: string]: (state: any) => any},
+  S = $Values<{[K in keyof T]: Parameters<T[K]>[0]}>,
+  R = {[K in keyof T]: ReturnType<T[K]>}
+>(
+  selectors: T
 ): OutputCachedSelector<
   S,
-  T,
-  (...args: $Values<T>[]) => T,
-  Selector<S, $Values<T>>[]
+  R,
+  (...args: $Values<R>[]) => R,
+  Selector<S, $Values<R>>[]
 >;
 
-export function createStructuredCachedSelector<S, P, T>(
-  selectors: {[K in keyof T]: ParametricSelector<S, P, T[K]>}
+export function createStructuredCachedSelector<
+  T extends {
+    [key: string]: (state: any, props: any, ...args: any[]) => any;
+  },
+  S = $Values<{[K in keyof T]: Parameters<T[K]>[0]}>,
+  P = Exclude<$Values<{[K in keyof T]: Parameters<T[K]>[1]}>, undefined>,
+  R = {[K in keyof T]: ReturnType<T[K]>}
+>(
+  selectors: T
 ): OutputParametricCachedSelector<
   S,
   P,
-  T,
-  (...args: $Values<T>[]) => T,
-  ParametricSelector<S, P, $Values<T>>[]
+  R,
+  (...args: $Values<R>[]) => R,
+  ParametricSelector<S, P, $Values<R>>[]
 >;
 
 /*

--- a/typescript_test/createCachedSelector.ts
+++ b/typescript_test/createCachedSelector.ts
@@ -79,9 +79,10 @@ function testInvalidTypeInCombinator() {
   type State = {foo: string; bar: number; baz: boolean};
 
   // typings:expect-error
-  createCachedSelector((state: State) => state.foo, (foo: number) => foo)(
-    (state: State) => foo
-  );
+  createCachedSelector(
+    (state: State) => state.foo,
+    (foo: number) => foo
+  )((state: State) => foo);
 
   // typings:expect-error
   createCachedSelector(
@@ -98,9 +99,9 @@ function testParametricSelector() {
 
   const selector = createCachedSelector(
     (state: State) => state.foo,
-    (state: never, props: Props) => props.bar,
+    (state: State, props: Props) => props.bar,
     (foo, bar) => ({foo, bar})
-  )((state: never, props: Props) => props.bar);
+  )((state: State, props: Props) => props.bar);
 
   const result = selector({foo: 'fizz'}, {bar: 42});
   const foo: string = result.foo;
@@ -144,20 +145,21 @@ function testParametricSelector() {
       foo5,
       bar,
     })
-  )((state: never, props: Props) => props.bar);
+  )((state: State, props: Props) => props.bar);
 
   selector2({foo: 'fizz'}, {bar: 42});
 }
 
 function testArrayArgument() {
+  type State = {foo: string};
   const selector = createCachedSelector(
     [
-      (state: {foo: string}) => state.foo,
-      (state: {foo: string}) => state.foo,
-      (state: never, props: {bar: number}) => props.bar,
+      (state: State) => state.foo,
+      (state: State) => state.foo,
+      (state: State, props: {bar: number}) => props.bar,
     ],
     (foo1, foo2, bar) => ({foo1, foo2, bar})
-  )((state: never, props: {bar: number}) => props.bar);
+  )((state: State, props: {bar: number}) => props.bar);
 
   const ret = selector({foo: 'fizz'}, {bar: 42});
   const foo1: string = ret.foo1;
@@ -176,7 +178,7 @@ function testArrayArgument() {
 
   createCachedSelector(
     [(state: {foo: string}) => state.foo, (state: {foo: string}) => state.foo],
-    (foo: string, bar: number) => {}
+    (foo: string, bar: string) => {}
   )((state: {foo: string}) => state.foo);
 
   createCachedSelector(
@@ -286,7 +288,7 @@ function testArrayArgument() {
 
   const parametric = createCachedSelector(
     [
-      (state: never, props: {bar: number}) => props.bar,
+      (state: {foo: string}, props: {bar: number}) => props.bar,
       (state: {foo: string}) => state.foo,
       (state: {foo: string}) => state.foo,
       (state: {foo: string}) => state.foo,
@@ -309,7 +311,7 @@ function testArrayArgument() {
     ) => {
       return {foo1, foo2, foo3, foo4, foo5, foo6, foo7, foo8, bar};
     }
-  )((state: never, props: {bar: number}) => props.bar);
+  )((state: any, props: {bar: number}) => props.bar);
 
   // typings:expect-error
   parametric({foo: 'fizz'});
@@ -335,17 +337,17 @@ function testKeySelector() {
 
   const selector = createCachedSelector(
     (state: State) => state.foo,
-    (state: never, arg1: number) => arg1,
-    (state: never, arg1: number, arg2: number) => arg1 + arg2,
+    (state: State, arg1: number) => arg1,
+    (state: State, arg1: number, arg2: number) => arg1 + arg2,
     (foo, arg1, sum) => ({foo, arg1, sum})
-  )((state: never, arg1: number, arg2: number) => arg1 + arg2);
+  )((state: State, arg1: number, arg2: number) => arg1 + arg2);
 
   selector({foo: 'fizz', obj: {bar: 'bar'}}, 1, 2);
 
   const selector2 = createCachedSelector(
     (state: State) => state.obj,
     obj => obj
-  )((state: never, obj) => obj);
+  )((state: State, obj) => obj);
 }
 
 function testSelectorCreatorOption() {
@@ -367,7 +369,10 @@ function testSelectorCreatorOption() {
   const selectorFailing = createCachedSelector(
     (state: State) => state.foo,
     foo => foo
-  )((state: State) => state.foo, (): void => {});
+  )(
+    (state: State) => state.foo,
+    (): void => {}
+  );
 }
 
 function testKeySelectorCreatorOption() {

--- a/typescript_test/createStructuredCachedSelector.ts
+++ b/typescript_test/createStructuredCachedSelector.ts
@@ -8,7 +8,10 @@ function testCreateStructuredCachedSelector() {
   const mySelectorA = (state: State) => state.a;
   const mySelectorB = (state: State) => state.b;
 
-  const selector = createStructuredCachedSelector({
+  const selector = createStructuredCachedSelector<
+    State,
+    {x: ReturnType<typeof mySelectorA>; y: ReturnType<typeof mySelectorB>}
+  >({
     x: mySelectorA,
     y: mySelectorB,
   })((state: State) => state.a);
@@ -27,7 +30,11 @@ function testParametricCreateStructuredCachedSelector() {
   const mySelectorA = (state: State) => state.a;
   const mySelectorB = (state: State, id: string) => state.items[id];
 
-  const selector = createStructuredCachedSelector({
+  const selector = createStructuredCachedSelector<
+    State,
+    string,
+    {x: ReturnType<typeof mySelectorA>; y: ReturnType<typeof mySelectorB>}
+  >({
     x: mySelectorA,
     y: mySelectorB,
   })((state: State, id: string) => id);

--- a/typescript_test/createStructuredCachedSelector.ts
+++ b/typescript_test/createStructuredCachedSelector.ts
@@ -8,10 +8,7 @@ function testCreateStructuredCachedSelector() {
   const mySelectorA = (state: State) => state.a;
   const mySelectorB = (state: State) => state.b;
 
-  const selector = createStructuredCachedSelector<
-    State,
-    {x: ReturnType<typeof mySelectorA>; y: ReturnType<typeof mySelectorB>}
-  >({
+  const selector = createStructuredCachedSelector({
     x: mySelectorA,
     y: mySelectorB,
   })((state: State) => state.a);
@@ -27,20 +24,26 @@ function testParametricCreateStructuredCachedSelector() {
   type Result = {x: string; y: string};
   type WrongResult = {x: string; y: number};
 
-  const mySelectorA = (state: State) => state.a;
+  const mySelectorA = (state: State, id: string) => state.a;
   const mySelectorB = (state: State, id: string) => state.items[id];
 
-  const selector = createStructuredCachedSelector<
-    State,
-    string,
-    {x: ReturnType<typeof mySelectorA>; y: ReturnType<typeof mySelectorB>}
-  >({
+  const selector = createStructuredCachedSelector({
     x: mySelectorA,
     y: mySelectorB,
   })((state: State, id: string) => id);
 
+  const selectorWithGenerics = createStructuredCachedSelector<
+    {x: typeof mySelectorA; y: typeof mySelectorB},
+    State,
+    string
+  >({
+    x: mySelectorA,
+    y: mySelectorB,
+  })((state: State) => state.a);
+
   const state: State = {a: 'foo', items: {foo: 'foo', bar: 'bar'}};
   const result: Result = selector(state, 'foo');
+  const resultG: Result = selectorWithGenerics(state, 'foo');
   // typings:expect-error
   const wrongResult: WrongResult = selector(state, 'foo');
 }

--- a/typescript_test/tsconfig.json
+++ b/typescript_test/tsconfig.json
@@ -1,10 +1,7 @@
 {
   "compilerOptions": {
     "module": "commonjs",
-    "noImplicitAny": true,
-    "strictNullChecks": true,
-    "lib": [
-      "es6"
-    ]
+    "strict": true,
+    "lib": ["es6"]
   }
 }


### PR DESCRIPTION
### What kind of change does this PR introduce? _(Bug fix, feature, docs update, ...)_

Type improvement

### What is the current behaviour? _(You can also link to an open issue here)_

#103 

### What is the new behaviour?

Autoinfer `createStructuredSelector` input type.

### Does this PR introduce a breaking change? _(What changes might users need to make in their application due to this PR?)_

TBD

### Other information:

### Please check if the PR fulfills these requirements:

- [X] Tests for the changes have been added
- [ ] Docs have been added / updated
