### PR TITLE
Omit 'clearCache' from CreateSelectorInstance type

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -32,7 +32,7 @@ export type OutputParametricSelector<S, P, R, C, D> = ParametricSelector<
   resetRecomputations: () => number;
 };
 
-export type CreateSelectorInstance = typeof createSelector;
+export type CreateSelectorInstance = Omit<typeof createSelector, 'clearCache'>;
 
 type Options<S, C, D> = {
   selectorCreator?: CreateSelectorInstance;

--- a/src/typescript_tests/createCachedSelector.test.ts
+++ b/src/typescript_tests/createCachedSelector.test.ts
@@ -415,3 +415,15 @@ function testSelectorCreatorOption() {
     selectorCreator: createSelectorCreator(defaultMemoize),
   });
 }
+
+function testSelectorCreatorOptionNonDefaultMemoize() {
+  type State = {foo: string};
+
+  const selector2 = createCachedSelector(
+    (state: State) => state.foo,
+    foo => foo
+  )({
+    keySelector: (state: State) => state.foo,
+    selectorCreator: createSelectorCreator((func) => func),
+  });
+}


### PR DESCRIPTION
### What kind of change does this PR introduce? _(Bug fix, feature, docs update, ...)_

Fixes #185 

### What is the new behaviour?

Omits `clearCache` from the `CreateSelectorInstance` type for the `selectorCreator` option.
Also add a typescript test that exercises this with a simple non-memoized selector.

### Does this PR introduce a breaking change? _(What changes might users need to make in their application due to this PR?)_

No, I've tested against reselect 4.0.0 and 4.1.5 from the current peerDependency (ie before and after the reselect signature change that came in 4.1.0).

### Other information:

### Please check if the PR fulfills these requirements:

- [x] Tests for the changes have been added
- [ ] Docs have been added / updated
