### PR TITLE
refactor: remove legacy APIs

### DIFF
--- a/jest/__snapshots__/bundles-snapshot.test.js.snap
+++ b/jest/__snapshots__/bundles-snapshot.test.js.snap
@@ -42,10 +42,7 @@ exports[`UMD bundle is unchanged 1`] = `
     for (var _len = arguments.length, funcs = new Array(_len), _key = 0; _key < _len; _key++) {
       funcs[_key] = arguments[_key];
     }
-    return function (polymorphicOptions, legacyOptions) {
-      if (legacyOptions) {
-        throw new Error('[re-reselect] "options" as second argument is not supported anymore. Please provide an option object as single argument.');
-      }
+    return function (polymorphicOptions) {
       var options = typeof polymorphicOptions === 'function' ? {
         keySelector: polymorphicOptions
       } : Object.assign({}, polymorphicOptions);
@@ -300,9 +297,6 @@ exports[`UMD bundle is unchanged 1`] = `
   exports.LruObjectCache = LruObjectCache;
   exports.createCachedSelector = createCachedSelector;
   exports.createStructuredCachedSelector = createStructuredCachedSelector;
-  exports.default = createCachedSelector;
-
-  Object.defineProperty(exports, '__esModule', { value: true });
 
 }));
 //# sourceMappingURL=index.js.map

--- a/src/__tests__/createCachedSelector.test.ts
+++ b/src/__tests__/createCachedSelector.test.ts
@@ -76,21 +76,6 @@ describe('createCachedSelector', () => {
         expect(cachedSelector.keySelector).toBe(generatedKeySelector);
       });
     });
-
-    describe('as second argument', () => {
-      it('throws an error', () => {
-        expect(() => {
-          createCachedSelector(
-            () => {},
-            () => {}
-          )(
-            () => {},
-            // @ts-expect-error
-            {}
-          );
-        }).toThrow(/"options" as second argument is not supported anymore/);
-      });
-    });
   });
 
   describe('created selector', () => {

--- a/src/__tests__/createCachedSelector.test.ts
+++ b/src/__tests__/createCachedSelector.test.ts
@@ -23,12 +23,6 @@ function selectorWithMockedResultFunc() {
 }
 
 describe('createCachedSelector', () => {
-  describe('default export', () => {
-    it('exports the same as "createCachedSelector"', () => {
-      expect(createCachedSelectorAsDefault).toBe(createCachedSelector);
-    });
-  });
-
   describe('options', () => {
     describe('as single function', () => {
       it('accepts keySelector function', () => {

--- a/src/createCachedSelector.js
+++ b/src/createCachedSelector.js
@@ -5,13 +5,7 @@ const defaultCacheCreator = FlatObjectCache;
 const defaultCacheKeyValidator = () => true;
 
 function createCachedSelector(...funcs) {
-  return (polymorphicOptions, legacyOptions) => {
-    if (legacyOptions) {
-      throw new Error(
-        '[re-reselect] "options" as second argument is not supported anymore. Please provide an option object as single argument.'
-      );
-    }
-
+  return polymorphicOptions => {
     const options =
       typeof polymorphicOptions === 'function'
         ? {keySelector: polymorphicOptions}

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -4251,7 +4251,6 @@ declare function createCachedSelector<S, P, R, T>(
   ParametricSelector<S, P, R>[]
 >;
 
-export default createCachedSelector;
 export {createCachedSelector};
 
 /*

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,4 @@
 import createCachedSelector from './createCachedSelector';
-export default createCachedSelector;
 export {createCachedSelector};
 
 export {default as createStructuredCachedSelector} from './createStructuredCachedSelector';

--- a/src/typescript_tests/createCachedSelector.ts
+++ b/src/typescript_tests/createCachedSelector.ts
@@ -1,15 +1,9 @@
 import {createSelectorCreator, lruMemoize} from 'reselect';
-import createCachedSelectorAsDefault, {
-  createCachedSelector,
-  KeySelector,
-} from '../index';
+import {createCachedSelector, KeySelector} from '../index';
 
 function assertType<T>(value: T): T {
   return value;
 }
-
-// default export and "createCachedSelector" named export are the same thing
-assertType<typeof createCachedSelector>(createCachedSelectorAsDefault);
 
 function testSelector() {
   type State = {foo: string};


### PR DESCRIPTION
### What kind of change does this PR introduce? _(Bug fix, feature, docs update, ...)_

Refactor

### What is the current behaviour? _(You can also link to an open issue here)_

`createCachedSelector`exported as default.

### What is the new behaviour?

`createCachedSelector`exported only as named export.

### Does this PR introduce a breaking change? _(What changes might users need to make in their application due to this PR?)_

Yes

### Other information:

### Please check if the PR fulfills these requirements:

- [X] Tests for the changes have been added
- [X] Docs have been added / updated
