### PR TITLE
feat: createCachedSelector accepts createSelectorOptions object

### DIFF
--- a/jest/__snapshots__/bundles-snapshot.test.ts.snap
+++ b/jest/__snapshots__/bundles-snapshot.test.ts.snap
@@ -38,10 +38,34 @@ exports[`UMD bundle is unchanged 1`] = `
   var defaultCacheKeyValidator = function defaultCacheKeyValidator() {
     return true;
   };
-  function createCachedSelector() {
-    for (var _len = arguments.length, funcs = new Array(_len), _key = 0; _key < _len; _key++) {
-      funcs[_key] = arguments[_key];
+  function parseReselectArgs(reselectArgs) {
+    var args = [].concat(reselectArgs);
+    var lastArgument = args[args.length - 1];
+    var resultFunc;
+    var createSelectorOptions = undefined;
+
+    // Last argument is resultFunc
+    if (typeof lastArgument === 'function') {
+      resultFunc = args.pop();
+    } else {
+      // Last argument is createSelectorOptions object
+      createSelectorOptions = args.pop();
+      resultFunc = args.pop();
     }
+    return {
+      inputSelectors: Array.isArray(args[0]) ? args[0] : [].concat(args),
+      resultFunc: resultFunc,
+      createSelectorOptions: createSelectorOptions
+    };
+  }
+  function createCachedSelector() {
+    for (var _len = arguments.length, reselectArgs = new Array(_len), _key = 0; _key < _len; _key++) {
+      reselectArgs[_key] = arguments[_key];
+    }
+    var _parseReselectArgs = parseReselectArgs(reselectArgs),
+      inputSelectors = _parseReselectArgs.inputSelectors,
+      resultFunc = _parseReselectArgs.resultFunc,
+      createSelectorOptions = _parseReselectArgs.createSelectorOptions;
     return function (polymorphicOptions) {
       var options = typeof polymorphicOptions === 'function' ? {
         keySelector: polymorphicOptions
@@ -49,31 +73,34 @@ exports[`UMD bundle is unchanged 1`] = `
 
       // https://github.com/reduxjs/reselect/blob/v4.0.0/src/index.js#L54
       var recomputations = 0;
-      var resultFunc = funcs.pop();
-      var dependencies = Array.isArray(funcs[0]) ? funcs[0] : [].concat(funcs);
       var resultFuncWithRecomputations = function resultFuncWithRecomputations() {
         recomputations++;
         return resultFunc.apply(void 0, arguments);
       };
-      funcs.push(resultFuncWithRecomputations);
+
+      // Patch reselect call arguments with a custom resultFunc
+      var patchedReselectArgs = [inputSelectors, resultFuncWithRecomputations];
+      if (createSelectorOptions) {
+        patchedReselectArgs.push(createSelectorOptions);
+      }
       var cache = options.cacheObject || new defaultCacheCreator();
       var selectorCreator = options.selectorCreator || reselect.createSelector;
       var isValidCacheKey = cache.isValidCacheKey || defaultCacheKeyValidator;
       if (options.keySelectorCreator) {
         options.keySelector = options.keySelectorCreator({
           keySelector: options.keySelector,
-          inputSelectors: dependencies,
+          inputSelectors: inputSelectors,
           resultFunc: resultFunc
         });
       }
 
-      // Application receives this function
+      // User receives this function
       var selector = function selector() {
         var cacheKey = options.keySelector.apply(options, arguments);
         if (isValidCacheKey(cacheKey)) {
           var cacheResponse = cache.get(cacheKey);
           if (cacheResponse === undefined) {
-            cacheResponse = selectorCreator.apply(void 0, funcs);
+            cacheResponse = selectorCreator.apply(void 0, patchedReselectArgs);
             cache.set(cacheKey, cacheResponse);
           }
           return cacheResponse.apply(void 0, arguments);
@@ -96,7 +123,7 @@ exports[`UMD bundle is unchanged 1`] = `
         cache.clear();
       };
       selector.resultFunc = resultFunc;
-      selector.dependencies = dependencies;
+      selector.dependencies = inputSelectors;
       selector.cache = cache;
       selector.recomputations = function () {
         return recomputations;

--- a/src/__tests__/createCachedSelector.test.ts
+++ b/src/__tests__/createCachedSelector.test.ts
@@ -1,5 +1,6 @@
 import * as reselect from 'reselect';
 import {createCachedSelector, FlatObjectCache, ICacheObject} from '../index';
+import type {CreateSelectorOptions} from 'reselect';
 
 // Cannot natively spyOn es module named exports
 jest.mock('reselect', () => ({
@@ -318,5 +319,30 @@ describe('createCachedSelector', () => {
         });
       });
     });
+  });
+
+  it("accepts and forwards reselect's createSelectorOptions object", () => {
+    const inputSelector1 = (state: string, param1: string) => null;
+    const createSelectorOptions: CreateSelectorOptions = {
+      memoizeOptions: {resultEqualityCheck: () => true},
+    };
+
+    const cachedSelector = createCachedSelector(
+      [inputSelector1],
+      () => {},
+      createSelectorOptions
+    )({keySelector: (state, param1) => param1});
+
+    cachedSelector('foo', 'bar');
+    cachedSelector('foo', 'bar');
+
+    expect(createSelectorSpy).toHaveBeenCalledTimes(1);
+    expect(createSelectorSpy).toHaveBeenCalledWith(
+      [inputSelector1],
+      expect.any(Function),
+      createSelectorOptions
+    );
+
+    expect(cachedSelector.recomputations()).toBe(1);
   });
 });

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,4 +1,4 @@
-import {createSelector} from 'reselect';
+import {createSelector, CreateSelectorOptions} from 'reselect';
 type $Values<T> = T[keyof T];
 
 export type Selector<S, R> = (state: S) => R;
@@ -79,11 +79,13 @@ export type OutputParametricCachedSelector<S, P, R, C, D> = (
 /* one selector */
 declare function createCachedSelector<S, R1, T>(
   selector: Selector<S, R1>,
-  combiner: (res: R1) => T
+  combiner: (res: R1) => T,
+  createSelectorOptions?: CreateSelectorOptions
 ): OutputCachedSelector<S, T, (res: R1) => T, [Selector<S, R1>]>;
 declare function createCachedSelector<S, P, R1, T>(
   selector: ParametricSelector<S, P, R1>,
-  combiner: (res: R1) => T
+  combiner: (res: R1) => T,
+  createSelectorOptions?: CreateSelectorOptions
 ): OutputParametricCachedSelector<
   S,
   P,
@@ -96,7 +98,8 @@ declare function createCachedSelector<S, P, R1, T>(
 declare function createCachedSelector<S, R1, R2, T>(
   selector1: Selector<S, R1>,
   selector2: Selector<S, R2>,
-  combiner: (res1: R1, res2: R2) => T
+  combiner: (res1: R1, res2: R2) => T,
+  createSelectorOptions?: CreateSelectorOptions
 ): OutputCachedSelector<
   S,
   T,
@@ -106,7 +109,8 @@ declare function createCachedSelector<S, R1, R2, T>(
 declare function createCachedSelector<S, P, R1, R2, T>(
   selector1: ParametricSelector<S, P, R1>,
   selector2: ParametricSelector<S, P, R2>,
-  combiner: (res1: R1, res2: R2) => T
+  combiner: (res1: R1, res2: R2) => T,
+  createSelectorOptions?: CreateSelectorOptions
 ): OutputParametricCachedSelector<
   S,
   P,
@@ -120,7 +124,8 @@ declare function createCachedSelector<S, R1, R2, R3, T>(
   selector1: Selector<S, R1>,
   selector2: Selector<S, R2>,
   selector3: Selector<S, R3>,
-  combiner: (res1: R1, res2: R2, res3: R3) => T
+  combiner: (res1: R1, res2: R2, res3: R3) => T,
+  createSelectorOptions?: CreateSelectorOptions
 ): OutputCachedSelector<
   S,
   T,
@@ -131,7 +136,8 @@ declare function createCachedSelector<S, P, R1, R2, R3, T>(
   selector1: ParametricSelector<S, P, R1>,
   selector2: ParametricSelector<S, P, R2>,
   selector3: ParametricSelector<S, P, R3>,
-  combiner: (res1: R1, res2: R2, res3: R3) => T
+  combiner: (res1: R1, res2: R2, res3: R3) => T,
+  createSelectorOptions?: CreateSelectorOptions
 ): OutputParametricCachedSelector<
   S,
   P,
@@ -140,7 +146,7 @@ declare function createCachedSelector<S, P, R1, R2, R3, T>(
   [
     ParametricSelector<S, P, R1>,
     ParametricSelector<S, P, R2>,
-    ParametricSelector<S, P, R3>,
+    ParametricSelector<S, P, R3>
   ]
 >;
 
@@ -150,7 +156,8 @@ declare function createCachedSelector<S, R1, R2, R3, R4, T>(
   selector2: Selector<S, R2>,
   selector3: Selector<S, R3>,
   selector4: Selector<S, R4>,
-  combiner: (res1: R1, res2: R2, res3: R3, res4: R4) => T
+  combiner: (res1: R1, res2: R2, res3: R3, res4: R4) => T,
+  createSelectorOptions?: CreateSelectorOptions
 ): OutputCachedSelector<
   S,
   T,
@@ -162,7 +169,8 @@ declare function createCachedSelector<S, P, R1, R2, R3, R4, T>(
   selector2: ParametricSelector<S, P, R2>,
   selector3: ParametricSelector<S, P, R3>,
   selector4: ParametricSelector<S, P, R4>,
-  combiner: (res1: R1, res2: R2, res3: R3, res4: R4) => T
+  combiner: (res1: R1, res2: R2, res3: R3, res4: R4) => T,
+  createSelectorOptions?: CreateSelectorOptions
 ): OutputParametricCachedSelector<
   S,
   P,
@@ -172,7 +180,7 @@ declare function createCachedSelector<S, P, R1, R2, R3, R4, T>(
     ParametricSelector<S, P, R1>,
     ParametricSelector<S, P, R2>,
     ParametricSelector<S, P, R3>,
-    ParametricSelector<S, P, R4>,
+    ParametricSelector<S, P, R4>
   ]
 >;
 
@@ -183,7 +191,8 @@ declare function createCachedSelector<S, R1, R2, R3, R4, R5, T>(
   selector3: Selector<S, R3>,
   selector4: Selector<S, R4>,
   selector5: Selector<S, R5>,
-  combiner: (res1: R1, res2: R2, res3: R3, res4: R4, res5: R5) => T
+  combiner: (res1: R1, res2: R2, res3: R3, res4: R4, res5: R5) => T,
+  createSelectorOptions?: CreateSelectorOptions
 ): OutputCachedSelector<
   S,
   T,
@@ -193,7 +202,7 @@ declare function createCachedSelector<S, R1, R2, R3, R4, R5, T>(
     Selector<S, R2>,
     Selector<S, R3>,
     Selector<S, R4>,
-    Selector<S, R5>,
+    Selector<S, R5>
   ]
 >;
 declare function createCachedSelector<S, P, R1, R2, R3, R4, R5, T>(
@@ -202,7 +211,8 @@ declare function createCachedSelector<S, P, R1, R2, R3, R4, R5, T>(
   selector3: ParametricSelector<S, P, R3>,
   selector4: ParametricSelector<S, P, R4>,
   selector5: ParametricSelector<S, P, R5>,
-  combiner: (res1: R1, res2: R2, res3: R3, res4: R4, res5: R5) => T
+  combiner: (res1: R1, res2: R2, res3: R3, res4: R4, res5: R5) => T,
+  createSelectorOptions?: CreateSelectorOptions
 ): OutputParametricCachedSelector<
   S,
   P,
@@ -213,7 +223,7 @@ declare function createCachedSelector<S, P, R1, R2, R3, R4, R5, T>(
     ParametricSelector<S, P, R2>,
     ParametricSelector<S, P, R3>,
     ParametricSelector<S, P, R4>,
-    ParametricSelector<S, P, R5>,
+    ParametricSelector<S, P, R5>
   ]
 >;
 
@@ -225,7 +235,8 @@ declare function createCachedSelector<S, R1, R2, R3, R4, R5, R6, T>(
   selector4: Selector<S, R4>,
   selector5: Selector<S, R5>,
   selector6: Selector<S, R6>,
-  combiner: (res1: R1, res2: R2, res3: R3, res4: R4, res5: R5, res6: R6) => T
+  combiner: (res1: R1, res2: R2, res3: R3, res4: R4, res5: R5, res6: R6) => T,
+  createSelectorOptions?: CreateSelectorOptions
 ): OutputCachedSelector<
   S,
   T,
@@ -236,7 +247,7 @@ declare function createCachedSelector<S, R1, R2, R3, R4, R5, R6, T>(
     Selector<S, R3>,
     Selector<S, R4>,
     Selector<S, R5>,
-    Selector<S, R6>,
+    Selector<S, R6>
   ]
 >;
 declare function createCachedSelector<S, P, R1, R2, R3, R4, R5, R6, T>(
@@ -246,7 +257,8 @@ declare function createCachedSelector<S, P, R1, R2, R3, R4, R5, R6, T>(
   selector4: ParametricSelector<S, P, R4>,
   selector5: ParametricSelector<S, P, R5>,
   selector6: ParametricSelector<S, P, R6>,
-  combiner: (res1: R1, res2: R2, res3: R3, res4: R4, res5: R5, res6: R6) => T
+  combiner: (res1: R1, res2: R2, res3: R3, res4: R4, res5: R5, res6: R6) => T,
+  createSelectorOptions?: CreateSelectorOptions
 ): OutputParametricCachedSelector<
   S,
   P,
@@ -258,7 +270,7 @@ declare function createCachedSelector<S, P, R1, R2, R3, R4, R5, R6, T>(
     ParametricSelector<S, P, R3>,
     ParametricSelector<S, P, R4>,
     ParametricSelector<S, P, R5>,
-    ParametricSelector<S, P, R6>,
+    ParametricSelector<S, P, R6>
   ]
 >;
 
@@ -279,7 +291,8 @@ declare function createCachedSelector<S, R1, R2, R3, R4, R5, R6, R7, T>(
     res5: R5,
     res6: R6,
     res7: R7
-  ) => T
+  ) => T,
+  createSelectorOptions?: CreateSelectorOptions
 ): OutputCachedSelector<
   S,
   T,
@@ -291,7 +304,7 @@ declare function createCachedSelector<S, R1, R2, R3, R4, R5, R6, R7, T>(
     Selector<S, R4>,
     Selector<S, R5>,
     Selector<S, R6>,
-    Selector<S, R7>,
+    Selector<S, R7>
   ]
 >;
 declare function createCachedSelector<S, P, R1, R2, R3, R4, R5, R6, R7, T>(
@@ -310,7 +323,8 @@ declare function createCachedSelector<S, P, R1, R2, R3, R4, R5, R6, R7, T>(
     res5: R5,
     res6: R6,
     res7: R7
-  ) => T
+  ) => T,
+  createSelectorOptions?: CreateSelectorOptions
 ): OutputParametricCachedSelector<
   S,
   P,
@@ -323,7 +337,7 @@ declare function createCachedSelector<S, P, R1, R2, R3, R4, R5, R6, R7, T>(
     ParametricSelector<S, P, R4>,
     ParametricSelector<S, P, R5>,
     ParametricSelector<S, P, R6>,
-    ParametricSelector<S, P, R7>,
+    ParametricSelector<S, P, R7>
   ]
 >;
 
@@ -346,7 +360,8 @@ declare function createCachedSelector<S, R1, R2, R3, R4, R5, R6, R7, R8, T>(
     res6: R6,
     res7: R7,
     res8: R8
-  ) => T
+  ) => T,
+  createSelectorOptions?: CreateSelectorOptions
 ): OutputCachedSelector<
   S,
   T,
@@ -368,7 +383,7 @@ declare function createCachedSelector<S, R1, R2, R3, R4, R5, R6, R7, R8, T>(
     Selector<S, R5>,
     Selector<S, R6>,
     Selector<S, R7>,
-    Selector<S, R8>,
+    Selector<S, R8>
   ]
 >;
 declare function createCachedSelector<S, P, R1, R2, R3, R4, R5, R6, R7, R8, T>(
@@ -389,7 +404,8 @@ declare function createCachedSelector<S, P, R1, R2, R3, R4, R5, R6, R7, R8, T>(
     res6: R6,
     res7: R7,
     res8: R8
-  ) => T
+  ) => T,
+  createSelectorOptions?: CreateSelectorOptions
 ): OutputParametricCachedSelector<
   S,
   P,
@@ -412,7 +428,7 @@ declare function createCachedSelector<S, P, R1, R2, R3, R4, R5, R6, R7, R8, T>(
     ParametricSelector<S, P, R5>,
     ParametricSelector<S, P, R6>,
     ParametricSelector<S, P, R7>,
-    ParametricSelector<S, P, R8>,
+    ParametricSelector<S, P, R8>
   ]
 >;
 
@@ -437,7 +453,8 @@ declare function createCachedSelector<S, R1, R2, R3, R4, R5, R6, R7, R8, R9, T>(
     res7: R7,
     res8: R8,
     res9: R9
-  ) => T
+  ) => T,
+  createSelectorOptions?: CreateSelectorOptions
 ): OutputCachedSelector<
   S,
   T,
@@ -461,7 +478,7 @@ declare function createCachedSelector<S, R1, R2, R3, R4, R5, R6, R7, R8, R9, T>(
     Selector<S, R6>,
     Selector<S, R7>,
     Selector<S, R8>,
-    Selector<S, R9>,
+    Selector<S, R9>
   ]
 >;
 declare function createCachedSelector<
@@ -476,7 +493,7 @@ declare function createCachedSelector<
   R7,
   R8,
   R9,
-  T,
+  T
 >(
   selector1: ParametricSelector<S, P, R1>,
   selector2: ParametricSelector<S, P, R2>,
@@ -497,7 +514,8 @@ declare function createCachedSelector<
     res7: R7,
     res8: R8,
     res9: R9
-  ) => T
+  ) => T,
+  createSelectorOptions?: CreateSelectorOptions
 ): OutputParametricCachedSelector<
   S,
   P,
@@ -522,7 +540,7 @@ declare function createCachedSelector<
     ParametricSelector<S, P, R6>,
     ParametricSelector<S, P, R7>,
     ParametricSelector<S, P, R8>,
-    ParametricSelector<S, P, R9>,
+    ParametricSelector<S, P, R9>
   ]
 >;
 
@@ -539,7 +557,7 @@ declare function createCachedSelector<
   R8,
   R9,
   R10,
-  T,
+  T
 >(
   selector1: Selector<S, R1>,
   selector2: Selector<S, R2>,
@@ -562,7 +580,8 @@ declare function createCachedSelector<
     res8: R8,
     res9: R9,
     res10: R10
-  ) => T
+  ) => T,
+  createSelectorOptions?: CreateSelectorOptions
 ): OutputCachedSelector<
   S,
   T,
@@ -588,7 +607,7 @@ declare function createCachedSelector<
     Selector<S, R7>,
     Selector<S, R8>,
     Selector<S, R9>,
-    Selector<S, R10>,
+    Selector<S, R10>
   ]
 >;
 declare function createCachedSelector<
@@ -604,7 +623,7 @@ declare function createCachedSelector<
   R8,
   R9,
   R10,
-  T,
+  T
 >(
   selector1: ParametricSelector<S, P, R1>,
   selector2: ParametricSelector<S, P, R2>,
@@ -627,7 +646,8 @@ declare function createCachedSelector<
     res8: R8,
     res9: R9,
     res10: R10
-  ) => T
+  ) => T,
+  createSelectorOptions?: CreateSelectorOptions
 ): OutputParametricCachedSelector<
   S,
   P,
@@ -654,7 +674,7 @@ declare function createCachedSelector<
     ParametricSelector<S, P, R7>,
     ParametricSelector<S, P, R8>,
     ParametricSelector<S, P, R9>,
-    ParametricSelector<S, P, R10>,
+    ParametricSelector<S, P, R10>
   ]
 >;
 
@@ -672,7 +692,7 @@ declare function createCachedSelector<
   R9,
   R10,
   R11,
-  T,
+  T
 >(
   selector1: Selector<S, R1>,
   selector2: Selector<S, R2>,
@@ -697,7 +717,8 @@ declare function createCachedSelector<
     res9: R9,
     res10: R10,
     res11: R11
-  ) => T
+  ) => T,
+  createSelectorOptions?: CreateSelectorOptions
 ): OutputCachedSelector<
   S,
   T,
@@ -725,7 +746,7 @@ declare function createCachedSelector<
     Selector<S, R8>,
     Selector<S, R9>,
     Selector<S, R10>,
-    Selector<S, R11>,
+    Selector<S, R11>
   ]
 >;
 declare function createCachedSelector<
@@ -742,7 +763,7 @@ declare function createCachedSelector<
   R9,
   R10,
   R11,
-  T,
+  T
 >(
   selector1: ParametricSelector<S, P, R1>,
   selector2: ParametricSelector<S, P, R2>,
@@ -767,7 +788,8 @@ declare function createCachedSelector<
     res9: R9,
     res10: R10,
     res11: R11
-  ) => T
+  ) => T,
+  createSelectorOptions?: CreateSelectorOptions
 ): OutputParametricCachedSelector<
   S,
   P,
@@ -796,7 +818,7 @@ declare function createCachedSelector<
     ParametricSelector<S, P, R8>,
     ParametricSelector<S, P, R9>,
     ParametricSelector<S, P, R10>,
-    ParametricSelector<S, P, R11>,
+    ParametricSelector<S, P, R11>
   ]
 >;
 
@@ -815,7 +837,7 @@ declare function createCachedSelector<
   R10,
   R11,
   R12,
-  T,
+  T
 >(
   selector1: Selector<S, R1>,
   selector2: Selector<S, R2>,
@@ -842,7 +864,8 @@ declare function createCachedSelector<
     res10: R10,
     res11: R11,
     res12: R12
-  ) => T
+  ) => T,
+  createSelectorOptions?: CreateSelectorOptions
 ): OutputCachedSelector<
   S,
   T,
@@ -872,7 +895,7 @@ declare function createCachedSelector<
     Selector<S, R9>,
     Selector<S, R10>,
     Selector<S, R11>,
-    Selector<S, R12>,
+    Selector<S, R12>
   ]
 >;
 declare function createCachedSelector<
@@ -890,7 +913,7 @@ declare function createCachedSelector<
   R10,
   R11,
   R12,
-  T,
+  T
 >(
   selector1: ParametricSelector<S, P, R1>,
   selector2: ParametricSelector<S, P, R2>,
@@ -917,7 +940,8 @@ declare function createCachedSelector<
     res10: R10,
     res11: R11,
     res12: R12
-  ) => T
+  ) => T,
+  createSelectorOptions?: CreateSelectorOptions
 ): OutputParametricCachedSelector<
   S,
   P,
@@ -948,7 +972,7 @@ declare function createCachedSelector<
     ParametricSelector<S, P, R9>,
     ParametricSelector<S, P, R10>,
     ParametricSelector<S, P, R11>,
-    ParametricSelector<S, P, R12>,
+    ParametricSelector<S, P, R12>
   ]
 >;
 
@@ -959,11 +983,13 @@ declare function createCachedSelector<
 /* one selector */
 declare function createCachedSelector<S, R1, T>(
   selectors: [Selector<S, R1>],
-  combiner: (res: R1) => T
+  combiner: (res: R1) => T,
+  createSelectorOptions?: CreateSelectorOptions
 ): OutputCachedSelector<S, T, (res: R1) => T, [Selector<S, R1>]>;
 declare function createCachedSelector<S, P, R1, T>(
   selectors: [ParametricSelector<S, P, R1>],
-  combiner: (res: R1) => T
+  combiner: (res: R1) => T,
+  createSelectorOptions?: CreateSelectorOptions
 ): OutputParametricCachedSelector<
   S,
   P,
@@ -975,7 +1001,8 @@ declare function createCachedSelector<S, P, R1, T>(
 /* two selectors */
 declare function createCachedSelector<S, R1, R2, T>(
   selectors: [Selector<S, R1>, Selector<S, R2>],
-  combiner: (res1: R1, res2: R2) => T
+  combiner: (res1: R1, res2: R2) => T,
+  createSelectorOptions?: CreateSelectorOptions
 ): OutputCachedSelector<
   S,
   T,
@@ -984,7 +1011,8 @@ declare function createCachedSelector<S, R1, R2, T>(
 >;
 declare function createCachedSelector<S, P, R1, R2, T>(
   selectors: [ParametricSelector<S, P, R1>, ParametricSelector<S, P, R2>],
-  combiner: (res1: R1, res2: R2) => T
+  combiner: (res1: R1, res2: R2) => T,
+  createSelectorOptions?: CreateSelectorOptions
 ): OutputParametricCachedSelector<
   S,
   P,
@@ -996,7 +1024,8 @@ declare function createCachedSelector<S, P, R1, R2, T>(
 /* three selectors */
 declare function createCachedSelector<S, R1, R2, R3, T>(
   selectors: [Selector<S, R1>, Selector<S, R2>, Selector<S, R3>],
-  combiner: (res1: R1, res2: R2, res3: R3) => T
+  combiner: (res1: R1, res2: R2, res3: R3) => T,
+  createSelectorOptions?: CreateSelectorOptions
 ): OutputCachedSelector<
   S,
   T,
@@ -1007,9 +1036,10 @@ declare function createCachedSelector<S, P, R1, R2, R3, T>(
   selectors: [
     ParametricSelector<S, P, R1>,
     ParametricSelector<S, P, R2>,
-    ParametricSelector<S, P, R3>,
+    ParametricSelector<S, P, R3>
   ],
-  combiner: (res1: R1, res2: R2, res3: R3) => T
+  combiner: (res1: R1, res2: R2, res3: R3) => T,
+  createSelectorOptions?: CreateSelectorOptions
 ): OutputParametricCachedSelector<
   S,
   P,
@@ -1018,7 +1048,7 @@ declare function createCachedSelector<S, P, R1, R2, R3, T>(
   [
     ParametricSelector<S, P, R1>,
     ParametricSelector<S, P, R2>,
-    ParametricSelector<S, P, R3>,
+    ParametricSelector<S, P, R3>
   ]
 >;
 
@@ -1028,9 +1058,10 @@ declare function createCachedSelector<S, R1, R2, R3, R4, T>(
     Selector<S, R1>,
     Selector<S, R2>,
     Selector<S, R3>,
-    Selector<S, R4>,
+    Selector<S, R4>
   ],
-  combiner: (res1: R1, res2: R2, res3: R3, res4: R4) => T
+  combiner: (res1: R1, res2: R2, res3: R3, res4: R4) => T,
+  createSelectorOptions?: CreateSelectorOptions
 ): OutputCachedSelector<
   S,
   T,
@@ -1042,9 +1073,10 @@ declare function createCachedSelector<S, P, R1, R2, R3, R4, T>(
     ParametricSelector<S, P, R1>,
     ParametricSelector<S, P, R2>,
     ParametricSelector<S, P, R3>,
-    ParametricSelector<S, P, R4>,
+    ParametricSelector<S, P, R4>
   ],
-  combiner: (res1: R1, res2: R2, res3: R3, res4: R4) => T
+  combiner: (res1: R1, res2: R2, res3: R3, res4: R4) => T,
+  createSelectorOptions?: CreateSelectorOptions
 ): OutputParametricCachedSelector<
   S,
   P,
@@ -1054,7 +1086,7 @@ declare function createCachedSelector<S, P, R1, R2, R3, R4, T>(
     ParametricSelector<S, P, R1>,
     ParametricSelector<S, P, R2>,
     ParametricSelector<S, P, R3>,
-    ParametricSelector<S, P, R4>,
+    ParametricSelector<S, P, R4>
   ]
 >;
 
@@ -1065,9 +1097,10 @@ declare function createCachedSelector<S, R1, R2, R3, R4, R5, T>(
     Selector<S, R2>,
     Selector<S, R3>,
     Selector<S, R4>,
-    Selector<S, R5>,
+    Selector<S, R5>
   ],
-  combiner: (res1: R1, res2: R2, res3: R3, res4: R4, res5: R5) => T
+  combiner: (res1: R1, res2: R2, res3: R3, res4: R4, res5: R5) => T,
+  createSelectorOptions?: CreateSelectorOptions
 ): OutputCachedSelector<
   S,
   T,
@@ -1077,7 +1110,7 @@ declare function createCachedSelector<S, R1, R2, R3, R4, R5, T>(
     Selector<S, R2>,
     Selector<S, R3>,
     Selector<S, R4>,
-    Selector<S, R5>,
+    Selector<S, R5>
   ]
 >;
 declare function createCachedSelector<S, P, R1, R2, R3, R4, R5, T>(
@@ -1086,9 +1119,10 @@ declare function createCachedSelector<S, P, R1, R2, R3, R4, R5, T>(
     ParametricSelector<S, P, R2>,
     ParametricSelector<S, P, R3>,
     ParametricSelector<S, P, R4>,
-    ParametricSelector<S, P, R5>,
+    ParametricSelector<S, P, R5>
   ],
-  combiner: (res1: R1, res2: R2, res3: R3, res4: R4, res5: R5) => T
+  combiner: (res1: R1, res2: R2, res3: R3, res4: R4, res5: R5) => T,
+  createSelectorOptions?: CreateSelectorOptions
 ): OutputParametricCachedSelector<
   S,
   P,
@@ -1099,7 +1133,7 @@ declare function createCachedSelector<S, P, R1, R2, R3, R4, R5, T>(
     ParametricSelector<S, P, R2>,
     ParametricSelector<S, P, R3>,
     ParametricSelector<S, P, R4>,
-    ParametricSelector<S, P, R5>,
+    ParametricSelector<S, P, R5>
   ]
 >;
 
@@ -1111,9 +1145,10 @@ declare function createCachedSelector<S, R1, R2, R3, R4, R5, R6, T>(
     Selector<S, R3>,
     Selector<S, R4>,
     Selector<S, R5>,
-    Selector<S, R6>,
+    Selector<S, R6>
   ],
-  combiner: (res1: R1, res2: R2, res3: R3, res4: R4, res5: R5, res6: R6) => T
+  combiner: (res1: R1, res2: R2, res3: R3, res4: R4, res5: R5, res6: R6) => T,
+  createSelectorOptions?: CreateSelectorOptions
 ): OutputCachedSelector<
   S,
   T,
@@ -1124,7 +1159,7 @@ declare function createCachedSelector<S, R1, R2, R3, R4, R5, R6, T>(
     Selector<S, R3>,
     Selector<S, R4>,
     Selector<S, R5>,
-    Selector<S, R6>,
+    Selector<S, R6>
   ]
 >;
 declare function createCachedSelector<S, P, R1, R2, R3, R4, R5, R6, T>(
@@ -1134,9 +1169,10 @@ declare function createCachedSelector<S, P, R1, R2, R3, R4, R5, R6, T>(
     ParametricSelector<S, P, R3>,
     ParametricSelector<S, P, R4>,
     ParametricSelector<S, P, R5>,
-    ParametricSelector<S, P, R6>,
+    ParametricSelector<S, P, R6>
   ],
-  combiner: (res1: R1, res2: R2, res3: R3, res4: R4, res5: R5, res6: R6) => T
+  combiner: (res1: R1, res2: R2, res3: R3, res4: R4, res5: R5, res6: R6) => T,
+  createSelectorOptions?: CreateSelectorOptions
 ): OutputParametricCachedSelector<
   S,
   P,
@@ -1148,7 +1184,7 @@ declare function createCachedSelector<S, P, R1, R2, R3, R4, R5, R6, T>(
     ParametricSelector<S, P, R3>,
     ParametricSelector<S, P, R4>,
     ParametricSelector<S, P, R5>,
-    ParametricSelector<S, P, R6>,
+    ParametricSelector<S, P, R6>
   ]
 >;
 
@@ -1161,7 +1197,7 @@ declare function createCachedSelector<S, R1, R2, R3, R4, R5, R6, R7, T>(
     Selector<S, R4>,
     Selector<S, R5>,
     Selector<S, R6>,
-    Selector<S, R7>,
+    Selector<S, R7>
   ],
   combiner: (
     res1: R1,
@@ -1171,7 +1207,8 @@ declare function createCachedSelector<S, R1, R2, R3, R4, R5, R6, R7, T>(
     res5: R5,
     res6: R6,
     res7: R7
-  ) => T
+  ) => T,
+  createSelectorOptions?: CreateSelectorOptions
 ): OutputCachedSelector<
   S,
   T,
@@ -1183,7 +1220,7 @@ declare function createCachedSelector<S, R1, R2, R3, R4, R5, R6, R7, T>(
     Selector<S, R4>,
     Selector<S, R5>,
     Selector<S, R6>,
-    Selector<S, R7>,
+    Selector<S, R7>
   ]
 >;
 declare function createCachedSelector<S, P, R1, R2, R3, R4, R5, R6, R7, T>(
@@ -1194,7 +1231,7 @@ declare function createCachedSelector<S, P, R1, R2, R3, R4, R5, R6, R7, T>(
     ParametricSelector<S, P, R4>,
     ParametricSelector<S, P, R5>,
     ParametricSelector<S, P, R6>,
-    ParametricSelector<S, P, R7>,
+    ParametricSelector<S, P, R7>
   ],
   combiner: (
     res1: R1,
@@ -1204,7 +1241,8 @@ declare function createCachedSelector<S, P, R1, R2, R3, R4, R5, R6, R7, T>(
     res5: R5,
     res6: R6,
     res7: R7
-  ) => T
+  ) => T,
+  createSelectorOptions?: CreateSelectorOptions
 ): OutputParametricCachedSelector<
   S,
   P,
@@ -1217,7 +1255,7 @@ declare function createCachedSelector<S, P, R1, R2, R3, R4, R5, R6, R7, T>(
     ParametricSelector<S, P, R4>,
     ParametricSelector<S, P, R5>,
     ParametricSelector<S, P, R6>,
-    ParametricSelector<S, P, R7>,
+    ParametricSelector<S, P, R7>
   ]
 >;
 
@@ -1231,7 +1269,7 @@ declare function createCachedSelector<S, R1, R2, R3, R4, R5, R6, R7, R8, T>(
     Selector<S, R5>,
     Selector<S, R6>,
     Selector<S, R7>,
-    Selector<S, R8>,
+    Selector<S, R8>
   ],
   combiner: (
     res1: R1,
@@ -1242,7 +1280,8 @@ declare function createCachedSelector<S, R1, R2, R3, R4, R5, R6, R7, R8, T>(
     res6: R6,
     res7: R7,
     res8: R8
-  ) => T
+  ) => T,
+  createSelectorOptions?: CreateSelectorOptions
 ): OutputCachedSelector<
   S,
   T,
@@ -1264,7 +1303,7 @@ declare function createCachedSelector<S, R1, R2, R3, R4, R5, R6, R7, R8, T>(
     Selector<S, R5>,
     Selector<S, R6>,
     Selector<S, R7>,
-    Selector<S, R8>,
+    Selector<S, R8>
   ]
 >;
 declare function createCachedSelector<S, P, R1, R2, R3, R4, R5, R6, R7, R8, T>(
@@ -1276,7 +1315,7 @@ declare function createCachedSelector<S, P, R1, R2, R3, R4, R5, R6, R7, R8, T>(
     ParametricSelector<S, P, R5>,
     ParametricSelector<S, P, R6>,
     ParametricSelector<S, P, R7>,
-    ParametricSelector<S, P, R8>,
+    ParametricSelector<S, P, R8>
   ],
   combiner: (
     res1: R1,
@@ -1287,7 +1326,8 @@ declare function createCachedSelector<S, P, R1, R2, R3, R4, R5, R6, R7, R8, T>(
     res6: R6,
     res7: R7,
     res8: R8
-  ) => T
+  ) => T,
+  createSelectorOptions?: CreateSelectorOptions
 ): OutputParametricCachedSelector<
   S,
   P,
@@ -1310,7 +1350,7 @@ declare function createCachedSelector<S, P, R1, R2, R3, R4, R5, R6, R7, R8, T>(
     ParametricSelector<S, P, R5>,
     ParametricSelector<S, P, R6>,
     ParametricSelector<S, P, R7>,
-    ParametricSelector<S, P, R8>,
+    ParametricSelector<S, P, R8>
   ]
 >;
 
@@ -1325,7 +1365,7 @@ declare function createCachedSelector<S, R1, R2, R3, R4, R5, R6, R7, R8, R9, T>(
     Selector<S, R6>,
     Selector<S, R7>,
     Selector<S, R8>,
-    Selector<S, R9>,
+    Selector<S, R9>
   ],
   combiner: (
     res1: R1,
@@ -1337,7 +1377,8 @@ declare function createCachedSelector<S, R1, R2, R3, R4, R5, R6, R7, R8, R9, T>(
     res7: R7,
     res8: R8,
     res9: R9
-  ) => T
+  ) => T,
+  createSelectorOptions?: CreateSelectorOptions
 ): OutputCachedSelector<
   S,
   T,
@@ -1361,7 +1402,7 @@ declare function createCachedSelector<S, R1, R2, R3, R4, R5, R6, R7, R8, R9, T>(
     Selector<S, R6>,
     Selector<S, R7>,
     Selector<S, R8>,
-    Selector<S, R9>,
+    Selector<S, R9>
   ]
 >;
 declare function createCachedSelector<
@@ -1376,7 +1417,7 @@ declare function createCachedSelector<
   R7,
   R8,
   R9,
-  T,
+  T
 >(
   selectors: [
     ParametricSelector<S, P, R1>,
@@ -1387,7 +1428,7 @@ declare function createCachedSelector<
     ParametricSelector<S, P, R6>,
     ParametricSelector<S, P, R7>,
     ParametricSelector<S, P, R8>,
-    ParametricSelector<S, P, R9>,
+    ParametricSelector<S, P, R9>
   ],
   combiner: (
     res1: R1,
@@ -1399,7 +1440,8 @@ declare function createCachedSelector<
     res7: R7,
     res8: R8,
     res9: R9
-  ) => T
+  ) => T,
+  createSelectorOptions?: CreateSelectorOptions
 ): OutputParametricCachedSelector<
   S,
   P,
@@ -1424,7 +1466,7 @@ declare function createCachedSelector<
     ParametricSelector<S, P, R6>,
     ParametricSelector<S, P, R7>,
     ParametricSelector<S, P, R8>,
-    ParametricSelector<S, P, R9>,
+    ParametricSelector<S, P, R9>
   ]
 >;
 
@@ -1441,7 +1483,7 @@ declare function createCachedSelector<
   R8,
   R9,
   R10,
-  T,
+  T
 >(
   selectors: [
     Selector<S, R1>,
@@ -1453,7 +1495,7 @@ declare function createCachedSelector<
     Selector<S, R7>,
     Selector<S, R8>,
     Selector<S, R9>,
-    Selector<S, R10>,
+    Selector<S, R10>
   ],
   combiner: (
     res1: R1,
@@ -1466,7 +1508,8 @@ declare function createCachedSelector<
     res8: R8,
     res9: R9,
     res10: R10
-  ) => T
+  ) => T,
+  createSelectorOptions?: CreateSelectorOptions
 ): OutputCachedSelector<
   S,
   T,
@@ -1492,7 +1535,7 @@ declare function createCachedSelector<
     Selector<S, R7>,
     Selector<S, R8>,
     Selector<S, R9>,
-    Selector<S, R10>,
+    Selector<S, R10>
   ]
 >;
 declare function createCachedSelector<
@@ -1508,7 +1551,7 @@ declare function createCachedSelector<
   R8,
   R9,
   R10,
-  T,
+  T
 >(
   selectors: [
     ParametricSelector<S, P, R1>,
@@ -1520,7 +1563,7 @@ declare function createCachedSelector<
     ParametricSelector<S, P, R7>,
     ParametricSelector<S, P, R8>,
     ParametricSelector<S, P, R9>,
-    ParametricSelector<S, P, R10>,
+    ParametricSelector<S, P, R10>
   ],
   combiner: (
     res1: R1,
@@ -1533,7 +1576,8 @@ declare function createCachedSelector<
     res8: R8,
     res9: R9,
     res10: R10
-  ) => T
+  ) => T,
+  createSelectorOptions?: CreateSelectorOptions
 ): OutputParametricCachedSelector<
   S,
   P,
@@ -1560,7 +1604,7 @@ declare function createCachedSelector<
     ParametricSelector<S, P, R7>,
     ParametricSelector<S, P, R8>,
     ParametricSelector<S, P, R9>,
-    ParametricSelector<S, P, R10>,
+    ParametricSelector<S, P, R10>
   ]
 >;
 
@@ -1578,7 +1622,7 @@ declare function createCachedSelector<
   R9,
   R10,
   R11,
-  T,
+  T
 >(
   selectors: [
     Selector<S, R1>,
@@ -1591,7 +1635,7 @@ declare function createCachedSelector<
     Selector<S, R8>,
     Selector<S, R9>,
     Selector<S, R10>,
-    Selector<S, R11>,
+    Selector<S, R11>
   ],
   combiner: (
     res1: R1,
@@ -1605,7 +1649,8 @@ declare function createCachedSelector<
     res9: R9,
     res10: R10,
     res11: R11
-  ) => T
+  ) => T,
+  createSelectorOptions?: CreateSelectorOptions
 ): OutputCachedSelector<
   S,
   T,
@@ -1633,7 +1678,7 @@ declare function createCachedSelector<
     Selector<S, R8>,
     Selector<S, R9>,
     Selector<S, R10>,
-    Selector<S, R11>,
+    Selector<S, R11>
   ]
 >;
 declare function createCachedSelector<
@@ -1650,7 +1695,7 @@ declare function createCachedSelector<
   R9,
   R10,
   R11,
-  T,
+  T
 >(
   selectors: [
     ParametricSelector<S, P, R1>,
@@ -1663,7 +1708,7 @@ declare function createCachedSelector<
     ParametricSelector<S, P, R8>,
     ParametricSelector<S, P, R9>,
     ParametricSelector<S, P, R10>,
-    ParametricSelector<S, P, R11>,
+    ParametricSelector<S, P, R11>
   ],
   combiner: (
     res1: R1,
@@ -1677,7 +1722,8 @@ declare function createCachedSelector<
     res9: R9,
     res10: R10,
     res11: R11
-  ) => T
+  ) => T,
+  createSelectorOptions?: CreateSelectorOptions
 ): OutputParametricCachedSelector<
   S,
   P,
@@ -1706,7 +1752,7 @@ declare function createCachedSelector<
     ParametricSelector<S, P, R8>,
     ParametricSelector<S, P, R9>,
     ParametricSelector<S, P, R10>,
-    ParametricSelector<S, P, R11>,
+    ParametricSelector<S, P, R11>
   ]
 >;
 
@@ -1725,7 +1771,7 @@ declare function createCachedSelector<
   R10,
   R11,
   R12,
-  T,
+  T
 >(
   selectors: [
     Selector<S, R1>,
@@ -1739,7 +1785,7 @@ declare function createCachedSelector<
     Selector<S, R9>,
     Selector<S, R10>,
     Selector<S, R11>,
-    Selector<S, R12>,
+    Selector<S, R12>
   ],
   combiner: (
     res1: R1,
@@ -1754,7 +1800,8 @@ declare function createCachedSelector<
     res10: R10,
     res11: R11,
     res12: R12
-  ) => T
+  ) => T,
+  createSelectorOptions?: CreateSelectorOptions
 ): OutputCachedSelector<
   S,
   T,
@@ -1784,7 +1831,7 @@ declare function createCachedSelector<
     Selector<S, R9>,
     Selector<S, R10>,
     Selector<S, R11>,
-    Selector<S, R12>,
+    Selector<S, R12>
   ]
 >;
 declare function createCachedSelector<
@@ -1802,7 +1849,7 @@ declare function createCachedSelector<
   R10,
   R11,
   R12,
-  T,
+  T
 >(
   selectors: [
     ParametricSelector<S, P, R1>,
@@ -1816,7 +1863,7 @@ declare function createCachedSelector<
     ParametricSelector<S, P, R9>,
     ParametricSelector<S, P, R10>,
     ParametricSelector<S, P, R11>,
-    ParametricSelector<S, P, R12>,
+    ParametricSelector<S, P, R12>
   ],
   combiner: (
     res1: R1,
@@ -1831,7 +1878,8 @@ declare function createCachedSelector<
     res10: R10,
     res11: R11,
     res12: R12
-  ) => T
+  ) => T,
+  createSelectorOptions?: CreateSelectorOptions
 ): OutputParametricCachedSelector<
   S,
   P,
@@ -1862,7 +1910,7 @@ declare function createCachedSelector<
     ParametricSelector<S, P, R9>,
     ParametricSelector<S, P, R10>,
     ParametricSelector<S, P, R11>,
-    ParametricSelector<S, P, R12>,
+    ParametricSelector<S, P, R12>
   ]
 >;
 
@@ -1873,11 +1921,13 @@ declare function createCachedSelector<
 /* one selector */
 declare function createCachedSelector<S1, R1, T>(
   selector: Selector<S1, R1>,
-  combiner: (res: R1) => T
+  combiner: (res: R1) => T,
+  createSelectorOptions?: CreateSelectorOptions
 ): OutputCachedSelector<S1, T, (res: R1) => T, [Selector<S1, R1>]>;
 declare function createCachedSelector<S1, P1, R1, T>(
   selector: ParametricSelector<S1, P1, R1>,
-  combiner: (res: R1) => T
+  combiner: (res: R1) => T,
+  createSelectorOptions?: CreateSelectorOptions
 ): OutputParametricCachedSelector<
   S1,
   P1,
@@ -1890,7 +1940,8 @@ declare function createCachedSelector<S1, P1, R1, T>(
 declare function createCachedSelector<S1, S2, R1, R2, T>(
   selector1: Selector<S1, R1>,
   selector2: Selector<S2, R2>,
-  combiner: (res1: R1, res2: R2) => T
+  combiner: (res1: R1, res2: R2) => T,
+  createSelectorOptions?: CreateSelectorOptions
 ): OutputCachedSelector<
   S1 & S2,
   T,
@@ -1900,7 +1951,8 @@ declare function createCachedSelector<S1, S2, R1, R2, T>(
 declare function createCachedSelector<S1, S2, P1, P2, R1, R2, T>(
   selector1: ParametricSelector<S1, P1, R1>,
   selector2: ParametricSelector<S2, P2, R2>,
-  combiner: (res1: R1, res2: R2) => T
+  combiner: (res1: R1, res2: R2) => T,
+  createSelectorOptions?: CreateSelectorOptions
 ): OutputParametricCachedSelector<
   S1 & S2,
   P1 & P2,
@@ -1914,7 +1966,8 @@ declare function createCachedSelector<S1, S2, S3, R1, R2, R3, T>(
   selector1: Selector<S1, R1>,
   selector2: Selector<S2, R2>,
   selector3: Selector<S3, R3>,
-  combiner: (res1: R1, res2: R2, res3: R3) => T
+  combiner: (res1: R1, res2: R2, res3: R3) => T,
+  createSelectorOptions?: CreateSelectorOptions
 ): OutputCachedSelector<
   S1 & S2 & S3,
   T,
@@ -1925,7 +1978,8 @@ declare function createCachedSelector<S1, S2, S3, P1, P2, P3, R1, R2, R3, T>(
   selector1: ParametricSelector<S1, P1, R1>,
   selector2: ParametricSelector<S2, P2, R2>,
   selector3: ParametricSelector<S3, P3, R3>,
-  combiner: (res1: R1, res2: R2, res3: R3) => T
+  combiner: (res1: R1, res2: R2, res3: R3) => T,
+  createSelectorOptions?: CreateSelectorOptions
 ): OutputParametricCachedSelector<
   S1 & S2 & S3,
   P1 & P2 & P3,
@@ -1934,7 +1988,7 @@ declare function createCachedSelector<S1, S2, S3, P1, P2, P3, R1, R2, R3, T>(
   [
     ParametricSelector<S1, P1, R1>,
     ParametricSelector<S2, P2, R2>,
-    ParametricSelector<S3, P3, R3>,
+    ParametricSelector<S3, P3, R3>
   ]
 >;
 
@@ -1944,7 +1998,8 @@ declare function createCachedSelector<S1, S2, S3, S4, R1, R2, R3, R4, T>(
   selector2: Selector<S2, R2>,
   selector3: Selector<S3, R3>,
   selector4: Selector<S4, R4>,
-  combiner: (res1: R1, res2: R2, res3: R3, res4: R4) => T
+  combiner: (res1: R1, res2: R2, res3: R3, res4: R4) => T,
+  createSelectorOptions?: CreateSelectorOptions
 ): OutputCachedSelector<
   S1 & S2 & S3 & S4,
   T,
@@ -1964,13 +2019,14 @@ declare function createCachedSelector<
   R2,
   R3,
   R4,
-  T,
+  T
 >(
   selector1: ParametricSelector<S1, P1, R1>,
   selector2: ParametricSelector<S2, P2, R2>,
   selector3: ParametricSelector<S3, P3, R3>,
   selector4: ParametricSelector<S4, P4, R4>,
-  combiner: (res1: R1, res2: R2, res3: R3, res4: R4) => T
+  combiner: (res1: R1, res2: R2, res3: R3, res4: R4) => T,
+  createSelectorOptions?: CreateSelectorOptions
 ): OutputParametricCachedSelector<
   S1 & S2 & S3 & S4,
   P1 & P2 & P3 & P4,
@@ -1980,7 +2036,7 @@ declare function createCachedSelector<
     ParametricSelector<S1, P1, R1>,
     ParametricSelector<S2, P2, R2>,
     ParametricSelector<S3, P3, R3>,
-    ParametricSelector<S4, P4, R4>,
+    ParametricSelector<S4, P4, R4>
   ]
 >;
 
@@ -1996,14 +2052,15 @@ declare function createCachedSelector<
   R3,
   R4,
   R5,
-  T,
+  T
 >(
   selector1: Selector<S1, R1>,
   selector2: Selector<S2, R2>,
   selector3: Selector<S3, R3>,
   selector4: Selector<S4, R4>,
   selector5: Selector<S5, R5>,
-  combiner: (res1: R1, res2: R2, res3: R3, res4: R4, res5: R5) => T
+  combiner: (res1: R1, res2: R2, res3: R3, res4: R4, res5: R5) => T,
+  createSelectorOptions?: CreateSelectorOptions
 ): OutputCachedSelector<
   S1 & S2 & S3 & S4 & S5,
   T,
@@ -2013,7 +2070,7 @@ declare function createCachedSelector<
     Selector<S2, R2>,
     Selector<S3, R3>,
     Selector<S4, R4>,
-    Selector<S5, R5>,
+    Selector<S5, R5>
   ]
 >;
 declare function createCachedSelector<
@@ -2032,14 +2089,15 @@ declare function createCachedSelector<
   R3,
   R4,
   R5,
-  T,
+  T
 >(
   selector1: ParametricSelector<S1, P1, R1>,
   selector2: ParametricSelector<S2, P2, R2>,
   selector3: ParametricSelector<S3, P3, R3>,
   selector4: ParametricSelector<S4, P4, R4>,
   selector5: ParametricSelector<S5, P5, R5>,
-  combiner: (res1: R1, res2: R2, res3: R3, res4: R4, res5: R5) => T
+  combiner: (res1: R1, res2: R2, res3: R3, res4: R4, res5: R5) => T,
+  createSelectorOptions?: CreateSelectorOptions
 ): OutputParametricCachedSelector<
   S1 & S2 & S3 & S4 & S5,
   P1 & P2 & P3 & P4 & P5,
@@ -2050,7 +2108,7 @@ declare function createCachedSelector<
     ParametricSelector<S2, P2, R2>,
     ParametricSelector<S3, P3, R3>,
     ParametricSelector<S4, P4, R4>,
-    ParametricSelector<S5, P5, R5>,
+    ParametricSelector<S5, P5, R5>
   ]
 >;
 
@@ -2068,7 +2126,7 @@ declare function createCachedSelector<
   R4,
   R5,
   R6,
-  T,
+  T
 >(
   selector1: Selector<S1, R1>,
   selector2: Selector<S2, R2>,
@@ -2076,7 +2134,8 @@ declare function createCachedSelector<
   selector4: Selector<S4, R4>,
   selector5: Selector<S5, R5>,
   selector6: Selector<S6, R6>,
-  combiner: (res1: R1, res2: R2, res3: R3, res4: R4, res5: R5, res6: R6) => T
+  combiner: (res1: R1, res2: R2, res3: R3, res4: R4, res5: R5, res6: R6) => T,
+  createSelectorOptions?: CreateSelectorOptions
 ): OutputCachedSelector<
   S1 & S2 & S3 & S4 & S5 & S6,
   T,
@@ -2087,7 +2146,7 @@ declare function createCachedSelector<
     Selector<S3, R3>,
     Selector<S4, R4>,
     Selector<S5, R5>,
-    Selector<S6, R6>,
+    Selector<S6, R6>
   ]
 >;
 declare function createCachedSelector<
@@ -2109,7 +2168,7 @@ declare function createCachedSelector<
   R4,
   R5,
   R6,
-  T,
+  T
 >(
   selector1: ParametricSelector<S1, P1, R1>,
   selector2: ParametricSelector<S2, P2, R2>,
@@ -2117,7 +2176,8 @@ declare function createCachedSelector<
   selector4: ParametricSelector<S4, P4, R4>,
   selector5: ParametricSelector<S5, P5, R5>,
   selector6: ParametricSelector<S6, P6, R6>,
-  combiner: (res1: R1, res2: R2, res3: R3, res4: R4, res5: R5, res6: R6) => T
+  combiner: (res1: R1, res2: R2, res3: R3, res4: R4, res5: R5, res6: R6) => T,
+  createSelectorOptions?: CreateSelectorOptions
 ): OutputParametricCachedSelector<
   S1 & S2 & S3 & S4 & S5 & S6,
   P1 & P2 & P3 & P4 & P5 & P6,
@@ -2129,7 +2189,7 @@ declare function createCachedSelector<
     ParametricSelector<S3, P3, R3>,
     ParametricSelector<S4, P4, R4>,
     ParametricSelector<S5, P5, R5>,
-    ParametricSelector<S6, P6, R6>,
+    ParametricSelector<S6, P6, R6>
   ]
 >;
 
@@ -2149,7 +2209,7 @@ declare function createCachedSelector<
   R5,
   R6,
   R7,
-  T,
+  T
 >(
   selector1: Selector<S1, R1>,
   selector2: Selector<S2, R2>,
@@ -2166,7 +2226,8 @@ declare function createCachedSelector<
     res5: R5,
     res6: R6,
     res7: R7
-  ) => T
+  ) => T,
+  createSelectorOptions?: CreateSelectorOptions
 ): OutputCachedSelector<
   S1 & S2 & S3 & S4 & S5 & S6 & S7,
   T,
@@ -2178,7 +2239,7 @@ declare function createCachedSelector<
     Selector<S4, R4>,
     Selector<S5, R5>,
     Selector<S6, R6>,
-    Selector<S7, R7>,
+    Selector<S7, R7>
   ]
 >;
 declare function createCachedSelector<
@@ -2203,7 +2264,7 @@ declare function createCachedSelector<
   R5,
   R6,
   R7,
-  T,
+  T
 >(
   selector1: ParametricSelector<S1, P1, R1>,
   selector2: ParametricSelector<S2, P2, R2>,
@@ -2220,7 +2281,8 @@ declare function createCachedSelector<
     res5: R5,
     res6: R6,
     res7: R7
-  ) => T
+  ) => T,
+  createSelectorOptions?: CreateSelectorOptions
 ): OutputParametricCachedSelector<
   S1 & S2 & S3 & S4 & S5 & S6 & S7,
   P1 & P2 & P3 & P4 & P5 & P6 & P7,
@@ -2233,7 +2295,7 @@ declare function createCachedSelector<
     ParametricSelector<S4, P4, R4>,
     ParametricSelector<S5, P5, R5>,
     ParametricSelector<S6, P6, R6>,
-    ParametricSelector<S7, P7, R7>,
+    ParametricSelector<S7, P7, R7>
   ]
 >;
 
@@ -2255,7 +2317,7 @@ declare function createCachedSelector<
   R6,
   R7,
   R8,
-  T,
+  T
 >(
   selector1: Selector<S1, R1>,
   selector2: Selector<S2, R2>,
@@ -2274,7 +2336,8 @@ declare function createCachedSelector<
     res6: R6,
     res7: R7,
     res8: R8
-  ) => T
+  ) => T,
+  createSelectorOptions?: CreateSelectorOptions
 ): OutputCachedSelector<
   S1 & S2 & S3 & S4 & S5 & S6 & S7 & S8,
   T,
@@ -2296,7 +2359,7 @@ declare function createCachedSelector<
     Selector<S5, R5>,
     Selector<S6, R6>,
     Selector<S7, R7>,
-    Selector<S8, R8>,
+    Selector<S8, R8>
   ]
 >;
 declare function createCachedSelector<
@@ -2324,7 +2387,7 @@ declare function createCachedSelector<
   R6,
   R7,
   R8,
-  T,
+  T
 >(
   selector1: ParametricSelector<S1, P1, R1>,
   selector2: ParametricSelector<S2, P2, R2>,
@@ -2343,7 +2406,8 @@ declare function createCachedSelector<
     res6: R6,
     res7: R7,
     res8: R8
-  ) => T
+  ) => T,
+  createSelectorOptions?: CreateSelectorOptions
 ): OutputParametricCachedSelector<
   S1 & S2 & S3 & S4 & S5 & S6 & S7 & S8,
   P1 & P2 & P3 & P4 & P5 & P6 & P7 & P8,
@@ -2366,7 +2430,7 @@ declare function createCachedSelector<
     ParametricSelector<S5, P5, R5>,
     ParametricSelector<S6, P6, R6>,
     ParametricSelector<S7, P7, R7>,
-    ParametricSelector<S8, P8, R8>,
+    ParametricSelector<S8, P8, R8>
   ]
 >;
 
@@ -2390,7 +2454,7 @@ declare function createCachedSelector<
   R7,
   R8,
   R9,
-  T,
+  T
 >(
   selector1: Selector<S1, R1>,
   selector2: Selector<S2, R2>,
@@ -2411,7 +2475,8 @@ declare function createCachedSelector<
     res7: R7,
     res8: R8,
     res9: R9
-  ) => T
+  ) => T,
+  createSelectorOptions?: CreateSelectorOptions
 ): OutputCachedSelector<
   S1 & S2 & S3 & S4 & S5 & S6 & S7 & S8 & S9,
   T,
@@ -2435,7 +2500,7 @@ declare function createCachedSelector<
     Selector<S6, R6>,
     Selector<S7, R7>,
     Selector<S8, R8>,
-    Selector<S9, R9>,
+    Selector<S9, R9>
   ]
 >;
 declare function createCachedSelector<
@@ -2466,7 +2531,7 @@ declare function createCachedSelector<
   R7,
   R8,
   R9,
-  T,
+  T
 >(
   selector1: ParametricSelector<S1, P1, R1>,
   selector2: ParametricSelector<S2, P2, R2>,
@@ -2487,7 +2552,8 @@ declare function createCachedSelector<
     res7: R7,
     res8: R8,
     res9: R9
-  ) => T
+  ) => T,
+  createSelectorOptions?: CreateSelectorOptions
 ): OutputParametricCachedSelector<
   S1 & S2 & S3 & S4 & S5 & S6 & S7 & S8 & S9,
   P1 & P2 & P3 & P4 & P5 & P6 & P7 & P8 & P9,
@@ -2512,7 +2578,7 @@ declare function createCachedSelector<
     ParametricSelector<S6, P6, R6>,
     ParametricSelector<S7, P7, R7>,
     ParametricSelector<S8, P8, R8>,
-    ParametricSelector<S9, P9, R9>,
+    ParametricSelector<S9, P9, R9>
   ]
 >;
 
@@ -2538,7 +2604,7 @@ declare function createCachedSelector<
   R8,
   R9,
   R10,
-  T,
+  T
 >(
   selector1: Selector<S1, R1>,
   selector2: Selector<S2, R2>,
@@ -2561,7 +2627,8 @@ declare function createCachedSelector<
     res8: R8,
     res9: R9,
     res10: R10
-  ) => T
+  ) => T,
+  createSelectorOptions?: CreateSelectorOptions
 ): OutputCachedSelector<
   S1 & S2 & S3 & S4 & S5 & S6 & S7 & S8 & S9 & S10,
   T,
@@ -2587,7 +2654,7 @@ declare function createCachedSelector<
     Selector<S7, R7>,
     Selector<S8, R8>,
     Selector<S9, R9>,
-    Selector<S10, R10>,
+    Selector<S10, R10>
   ]
 >;
 declare function createCachedSelector<
@@ -2621,7 +2688,7 @@ declare function createCachedSelector<
   R8,
   R9,
   R10,
-  T,
+  T
 >(
   selector1: ParametricSelector<S1, P1, R1>,
   selector2: ParametricSelector<S2, P2, R2>,
@@ -2644,7 +2711,8 @@ declare function createCachedSelector<
     res8: R8,
     res9: R9,
     res10: R10
-  ) => T
+  ) => T,
+  createSelectorOptions?: CreateSelectorOptions
 ): OutputParametricCachedSelector<
   S1 & S2 & S3 & S4 & S5 & S6 & S7 & S8 & S9 & S10,
   P1 & P2 & P3 & P4 & P5 & P6 & P7 & P8 & P9 & P10,
@@ -2671,7 +2739,7 @@ declare function createCachedSelector<
     ParametricSelector<S7, P7, R7>,
     ParametricSelector<S8, P8, R8>,
     ParametricSelector<S9, P9, R9>,
-    ParametricSelector<S10, P10, R10>,
+    ParametricSelector<S10, P10, R10>
   ]
 >;
 
@@ -2699,7 +2767,7 @@ declare function createCachedSelector<
   R9,
   R10,
   R11,
-  T,
+  T
 >(
   selector1: Selector<S1, R1>,
   selector2: Selector<S2, R2>,
@@ -2724,7 +2792,8 @@ declare function createCachedSelector<
     res9: R9,
     res10: R10,
     res11: R11
-  ) => T
+  ) => T,
+  createSelectorOptions?: CreateSelectorOptions
 ): OutputCachedSelector<
   S1 & S2 & S3 & S4 & S5 & S6 & S7 & S8 & S9 & S10 & S11,
   T,
@@ -2752,7 +2821,7 @@ declare function createCachedSelector<
     Selector<S8, R8>,
     Selector<S9, R9>,
     Selector<S10, R10>,
-    Selector<S11, R11>,
+    Selector<S11, R11>
   ]
 >;
 declare function createCachedSelector<
@@ -2789,7 +2858,7 @@ declare function createCachedSelector<
   R9,
   R10,
   R11,
-  T,
+  T
 >(
   selector1: ParametricSelector<S1, P1, R1>,
   selector2: ParametricSelector<S2, P2, R2>,
@@ -2814,7 +2883,8 @@ declare function createCachedSelector<
     res9: R9,
     res10: R10,
     res11: R11
-  ) => T
+  ) => T,
+  createSelectorOptions?: CreateSelectorOptions
 ): OutputParametricCachedSelector<
   S1 & S2 & S3 & S4 & S5 & S6 & S7 & S8 & S9 & S10 & S11,
   P1 & P2 & P3 & P4 & P5 & P6 & P7 & P8 & P9 & P10 & P11,
@@ -2843,7 +2913,7 @@ declare function createCachedSelector<
     ParametricSelector<S8, P8, R8>,
     ParametricSelector<S9, P9, R9>,
     ParametricSelector<S10, P10, R10>,
-    ParametricSelector<S11, P11, R11>,
+    ParametricSelector<S11, P11, R11>
   ]
 >;
 
@@ -2873,7 +2943,7 @@ declare function createCachedSelector<
   R10,
   R11,
   R12,
-  T,
+  T
 >(
   selector1: Selector<S1, R1>,
   selector2: Selector<S2, R2>,
@@ -2900,7 +2970,8 @@ declare function createCachedSelector<
     res10: R10,
     res11: R11,
     res12: R12
-  ) => T
+  ) => T,
+  createSelectorOptions?: CreateSelectorOptions
 ): OutputCachedSelector<
   S1 & S2 & S3 & S4 & S5 & S6 & S7 & S8 & S9 & S10 & S11 & S12,
   T,
@@ -2930,7 +3001,7 @@ declare function createCachedSelector<
     Selector<S9, R9>,
     Selector<S10, R10>,
     Selector<S11, R11>,
-    Selector<S12, R12>,
+    Selector<S12, R12>
   ]
 >;
 declare function createCachedSelector<
@@ -2970,7 +3041,7 @@ declare function createCachedSelector<
   R10,
   R11,
   R12,
-  T,
+  T
 >(
   selector1: ParametricSelector<S1, P1, R1>,
   selector2: ParametricSelector<S2, P2, R2>,
@@ -2997,7 +3068,8 @@ declare function createCachedSelector<
     res10: R10,
     res11: R11,
     res12: R12
-  ) => T
+  ) => T,
+  createSelectorOptions?: CreateSelectorOptions
 ): OutputParametricCachedSelector<
   S1 & S2 & S3 & S4 & S5 & S6 & S7 & S8 & S9 & S10 & S11 & S12,
   P1 & P2 & P3 & P4 & P5 & P6 & P7 & P8 & P9 & P10 & P11 & P12,
@@ -3028,7 +3100,7 @@ declare function createCachedSelector<
     ParametricSelector<S9, P9, R9>,
     ParametricSelector<S10, P10, R10>,
     ParametricSelector<S11, P11, R11>,
-    ParametricSelector<S12, P12, R12>,
+    ParametricSelector<S12, P12, R12>
   ]
 >;
 
@@ -3039,11 +3111,13 @@ declare function createCachedSelector<
 /* one selector */
 declare function createCachedSelector<S1, R1, T>(
   selectors: [Selector<S1, R1>],
-  combiner: (res: R1) => T
+  combiner: (res: R1) => T,
+  createSelectorOptions?: CreateSelectorOptions
 ): OutputCachedSelector<S1, T, (res: R1) => T, [Selector<S1, R1>]>;
 declare function createCachedSelector<S1, P1, R1, T>(
   selectors: [ParametricSelector<S1, P1, R1>],
-  combiner: (res: R1) => T
+  combiner: (res: R1) => T,
+  createSelectorOptions?: CreateSelectorOptions
 ): OutputParametricCachedSelector<
   S1,
   P1,
@@ -3055,7 +3129,8 @@ declare function createCachedSelector<S1, P1, R1, T>(
 /* two selectors */
 declare function createCachedSelector<S1, S2, R1, R2, T>(
   selectors: [Selector<S1, R1>, Selector<S2, R2>],
-  combiner: (res1: R1, res2: R2) => T
+  combiner: (res1: R1, res2: R2) => T,
+  createSelectorOptions?: CreateSelectorOptions
 ): OutputCachedSelector<
   S1 & S2,
   T,
@@ -3064,7 +3139,8 @@ declare function createCachedSelector<S1, S2, R1, R2, T>(
 >;
 declare function createCachedSelector<S1, S2, P1, P2, R1, R2, T>(
   selectors: [ParametricSelector<S1, P1, R1>, ParametricSelector<S2, P2, R2>],
-  combiner: (res1: R1, res2: R2) => T
+  combiner: (res1: R1, res2: R2) => T,
+  createSelectorOptions?: CreateSelectorOptions
 ): OutputParametricCachedSelector<
   S1 & S2,
   P1 & P2,
@@ -3076,7 +3152,8 @@ declare function createCachedSelector<S1, S2, P1, P2, R1, R2, T>(
 /* three selectors */
 declare function createCachedSelector<S1, S2, S3, R1, R2, R3, T>(
   selectors: [Selector<S1, R1>, Selector<S2, R2>, Selector<S3, R3>],
-  combiner: (res1: R1, res2: R2, res3: R3) => T
+  combiner: (res1: R1, res2: R2, res3: R3) => T,
+  createSelectorOptions?: CreateSelectorOptions
 ): OutputCachedSelector<
   S1 & S2 & S3,
   T,
@@ -3087,9 +3164,10 @@ declare function createCachedSelector<S1, S2, S3, P1, P2, P3, R1, R2, R3, T>(
   selectors: [
     ParametricSelector<S1, P1, R1>,
     ParametricSelector<S2, P2, R2>,
-    ParametricSelector<S3, P3, R3>,
+    ParametricSelector<S3, P3, R3>
   ],
-  combiner: (res1: R1, res2: R2, res3: R3) => T
+  combiner: (res1: R1, res2: R2, res3: R3) => T,
+  createSelectorOptions?: CreateSelectorOptions
 ): OutputParametricCachedSelector<
   S1 & S2 & S3,
   P1 & P2 & P3,
@@ -3098,7 +3176,7 @@ declare function createCachedSelector<S1, S2, S3, P1, P2, P3, R1, R2, R3, T>(
   [
     ParametricSelector<S1, P1, R1>,
     ParametricSelector<S2, P2, R2>,
-    ParametricSelector<S3, P3, R3>,
+    ParametricSelector<S3, P3, R3>
   ]
 >;
 
@@ -3108,9 +3186,10 @@ declare function createCachedSelector<S1, S2, S3, S4, R1, R2, R3, R4, T>(
     Selector<S1, R1>,
     Selector<S2, R2>,
     Selector<S3, R3>,
-    Selector<S4, R4>,
+    Selector<S4, R4>
   ],
-  combiner: (res1: R1, res2: R2, res3: R3, res4: R4) => T
+  combiner: (res1: R1, res2: R2, res3: R3, res4: R4) => T,
+  createSelectorOptions?: CreateSelectorOptions
 ): OutputCachedSelector<
   S1 & S2 & S3 & S4,
   T,
@@ -3130,15 +3209,16 @@ declare function createCachedSelector<
   R2,
   R3,
   R4,
-  T,
+  T
 >(
   selectors: [
     ParametricSelector<S1, P1, R1>,
     ParametricSelector<S2, P2, R2>,
     ParametricSelector<S3, P3, R3>,
-    ParametricSelector<S4, P4, R4>,
+    ParametricSelector<S4, P4, R4>
   ],
-  combiner: (res1: R1, res2: R2, res3: R3, res4: R4) => T
+  combiner: (res1: R1, res2: R2, res3: R3, res4: R4) => T,
+  createSelectorOptions?: CreateSelectorOptions
 ): OutputParametricCachedSelector<
   S1 & S2 & S3 & S4,
   P1 & P2 & P3 & P4,
@@ -3148,7 +3228,7 @@ declare function createCachedSelector<
     ParametricSelector<S1, P1, R1>,
     ParametricSelector<S2, P2, R2>,
     ParametricSelector<S3, P3, R3>,
-    ParametricSelector<S4, P4, R4>,
+    ParametricSelector<S4, P4, R4>
   ]
 >;
 
@@ -3164,16 +3244,17 @@ declare function createCachedSelector<
   R3,
   R4,
   R5,
-  T,
+  T
 >(
   selectors: [
     Selector<S1, R1>,
     Selector<S2, R2>,
     Selector<S3, R3>,
     Selector<S4, R4>,
-    Selector<S5, R5>,
+    Selector<S5, R5>
   ],
-  combiner: (res1: R1, res2: R2, res3: R3, res4: R4, res5: R5) => T
+  combiner: (res1: R1, res2: R2, res3: R3, res4: R4, res5: R5) => T,
+  createSelectorOptions?: CreateSelectorOptions
 ): OutputCachedSelector<
   S1 & S2 & S3 & S4 & S5,
   T,
@@ -3183,7 +3264,7 @@ declare function createCachedSelector<
     Selector<S2, R2>,
     Selector<S3, R3>,
     Selector<S4, R4>,
-    Selector<S5, R5>,
+    Selector<S5, R5>
   ]
 >;
 declare function createCachedSelector<
@@ -3202,16 +3283,17 @@ declare function createCachedSelector<
   R3,
   R4,
   R5,
-  T,
+  T
 >(
   selectors: [
     ParametricSelector<S1, P1, R1>,
     ParametricSelector<S2, P2, R2>,
     ParametricSelector<S3, P3, R3>,
     ParametricSelector<S4, P4, R4>,
-    ParametricSelector<S5, P5, R5>,
+    ParametricSelector<S5, P5, R5>
   ],
-  combiner: (res1: R1, res2: R2, res3: R3, res4: R4, res5: R5) => T
+  combiner: (res1: R1, res2: R2, res3: R3, res4: R4, res5: R5) => T,
+  createSelectorOptions?: CreateSelectorOptions
 ): OutputParametricCachedSelector<
   S1 & S2 & S3 & S4 & S5,
   P1 & P2 & P3 & P4 & P5,
@@ -3222,7 +3304,7 @@ declare function createCachedSelector<
     ParametricSelector<S2, P2, R2>,
     ParametricSelector<S3, P3, R3>,
     ParametricSelector<S4, P4, R4>,
-    ParametricSelector<S5, P5, R5>,
+    ParametricSelector<S5, P5, R5>
   ]
 >;
 
@@ -3240,7 +3322,7 @@ declare function createCachedSelector<
   R4,
   R5,
   R6,
-  T,
+  T
 >(
   selectors: [
     Selector<S1, R1>,
@@ -3248,9 +3330,10 @@ declare function createCachedSelector<
     Selector<S3, R3>,
     Selector<S4, R4>,
     Selector<S5, R5>,
-    Selector<S6, R6>,
+    Selector<S6, R6>
   ],
-  combiner: (res1: R1, res2: R2, res3: R3, res4: R4, res5: R5, res6: R6) => T
+  combiner: (res1: R1, res2: R2, res3: R3, res4: R4, res5: R5, res6: R6) => T,
+  createSelectorOptions?: CreateSelectorOptions
 ): OutputCachedSelector<
   S1 & S2 & S3 & S4 & S5 & S6,
   T,
@@ -3261,7 +3344,7 @@ declare function createCachedSelector<
     Selector<S3, R3>,
     Selector<S4, R4>,
     Selector<S5, R5>,
-    Selector<S6, R6>,
+    Selector<S6, R6>
   ]
 >;
 declare function createCachedSelector<
@@ -3283,7 +3366,7 @@ declare function createCachedSelector<
   R4,
   R5,
   R6,
-  T,
+  T
 >(
   selectors: [
     ParametricSelector<S1, P1, R1>,
@@ -3291,9 +3374,10 @@ declare function createCachedSelector<
     ParametricSelector<S3, P3, R3>,
     ParametricSelector<S4, P4, R4>,
     ParametricSelector<S5, P5, R5>,
-    ParametricSelector<S6, P6, R6>,
+    ParametricSelector<S6, P6, R6>
   ],
-  combiner: (res1: R1, res2: R2, res3: R3, res4: R4, res5: R5, res6: R6) => T
+  combiner: (res1: R1, res2: R2, res3: R3, res4: R4, res5: R5, res6: R6) => T,
+  createSelectorOptions?: CreateSelectorOptions
 ): OutputParametricCachedSelector<
   S1 & S2 & S3 & S4 & S5 & S6,
   P1 & P2 & P3 & P4 & P5 & P6,
@@ -3305,7 +3389,7 @@ declare function createCachedSelector<
     ParametricSelector<S3, P3, R3>,
     ParametricSelector<S4, P4, R4>,
     ParametricSelector<S5, P5, R5>,
-    ParametricSelector<S6, P6, R6>,
+    ParametricSelector<S6, P6, R6>
   ]
 >;
 
@@ -3325,7 +3409,7 @@ declare function createCachedSelector<
   R5,
   R6,
   R7,
-  T,
+  T
 >(
   selectors: [
     Selector<S1, R1>,
@@ -3334,7 +3418,7 @@ declare function createCachedSelector<
     Selector<S4, R4>,
     Selector<S5, R5>,
     Selector<S6, R6>,
-    Selector<S7, R7>,
+    Selector<S7, R7>
   ],
   combiner: (
     res1: R1,
@@ -3344,7 +3428,8 @@ declare function createCachedSelector<
     res5: R5,
     res6: R6,
     res7: R7
-  ) => T
+  ) => T,
+  createSelectorOptions?: CreateSelectorOptions
 ): OutputCachedSelector<
   S1 & S2 & S3 & S4 & S5 & S6 & S7,
   T,
@@ -3356,7 +3441,7 @@ declare function createCachedSelector<
     Selector<S4, R4>,
     Selector<S5, R5>,
     Selector<S6, R6>,
-    Selector<S7, R7>,
+    Selector<S7, R7>
   ]
 >;
 declare function createCachedSelector<
@@ -3381,7 +3466,7 @@ declare function createCachedSelector<
   R5,
   R6,
   R7,
-  T,
+  T
 >(
   selectors: [
     ParametricSelector<S1, P1, R1>,
@@ -3390,7 +3475,7 @@ declare function createCachedSelector<
     ParametricSelector<S4, P4, R4>,
     ParametricSelector<S5, P5, R5>,
     ParametricSelector<S6, P6, R6>,
-    ParametricSelector<S7, P7, R7>,
+    ParametricSelector<S7, P7, R7>
   ],
   combiner: (
     res1: R1,
@@ -3400,7 +3485,8 @@ declare function createCachedSelector<
     res5: R5,
     res6: R6,
     res7: R7
-  ) => T
+  ) => T,
+  createSelectorOptions?: CreateSelectorOptions
 ): OutputParametricCachedSelector<
   S1 & S2 & S3 & S4 & S5 & S6 & S7,
   P1 & P2 & P3 & P4 & P5 & P6 & P7,
@@ -3413,7 +3499,7 @@ declare function createCachedSelector<
     ParametricSelector<S4, P4, R4>,
     ParametricSelector<S5, P5, R5>,
     ParametricSelector<S6, P6, R6>,
-    ParametricSelector<S7, P7, R7>,
+    ParametricSelector<S7, P7, R7>
   ]
 >;
 
@@ -3435,7 +3521,7 @@ declare function createCachedSelector<
   R6,
   R7,
   R8,
-  T,
+  T
 >(
   selectors: [
     Selector<S1, R1>,
@@ -3445,7 +3531,7 @@ declare function createCachedSelector<
     Selector<S5, R5>,
     Selector<S6, R6>,
     Selector<S7, R7>,
-    Selector<S8, R8>,
+    Selector<S8, R8>
   ],
   combiner: (
     res1: R1,
@@ -3456,7 +3542,8 @@ declare function createCachedSelector<
     res6: R6,
     res7: R7,
     res8: R8
-  ) => T
+  ) => T,
+  createSelectorOptions?: CreateSelectorOptions
 ): OutputCachedSelector<
   S1 & S2 & S3 & S4 & S5 & S6 & S7 & S8,
   T,
@@ -3478,7 +3565,7 @@ declare function createCachedSelector<
     Selector<S5, R5>,
     Selector<S6, R6>,
     Selector<S7, R7>,
-    Selector<S8, R8>,
+    Selector<S8, R8>
   ]
 >;
 declare function createCachedSelector<
@@ -3506,7 +3593,7 @@ declare function createCachedSelector<
   R6,
   R7,
   R8,
-  T,
+  T
 >(
   selectors: [
     ParametricSelector<S1, P1, R1>,
@@ -3516,7 +3603,7 @@ declare function createCachedSelector<
     ParametricSelector<S5, P5, R5>,
     ParametricSelector<S6, P6, R6>,
     ParametricSelector<S7, P7, R7>,
-    ParametricSelector<S8, P8, R8>,
+    ParametricSelector<S8, P8, R8>
   ],
   combiner: (
     res1: R1,
@@ -3527,7 +3614,8 @@ declare function createCachedSelector<
     res6: R6,
     res7: R7,
     res8: R8
-  ) => T
+  ) => T,
+  createSelectorOptions?: CreateSelectorOptions
 ): OutputParametricCachedSelector<
   S1 & S2 & S3 & S4 & S5 & S6 & S7 & S8,
   P1 & P2 & P3 & P4 & P5 & P6 & P7 & P8,
@@ -3550,7 +3638,7 @@ declare function createCachedSelector<
     ParametricSelector<S5, P5, R5>,
     ParametricSelector<S6, P6, R6>,
     ParametricSelector<S7, P7, R7>,
-    ParametricSelector<S8, P8, R8>,
+    ParametricSelector<S8, P8, R8>
   ]
 >;
 
@@ -3574,7 +3662,7 @@ declare function createCachedSelector<
   R7,
   R8,
   R9,
-  T,
+  T
 >(
   selectors: [
     Selector<S1, R1>,
@@ -3585,7 +3673,7 @@ declare function createCachedSelector<
     Selector<S6, R6>,
     Selector<S7, R7>,
     Selector<S8, R8>,
-    Selector<S9, R9>,
+    Selector<S9, R9>
   ],
   combiner: (
     res1: R1,
@@ -3597,7 +3685,8 @@ declare function createCachedSelector<
     res7: R7,
     res8: R8,
     res9: R9
-  ) => T
+  ) => T,
+  createSelectorOptions?: CreateSelectorOptions
 ): OutputCachedSelector<
   S1 & S2 & S3 & S4 & S5 & S6 & S7 & S8 & S9,
   T,
@@ -3621,7 +3710,7 @@ declare function createCachedSelector<
     Selector<S6, R6>,
     Selector<S7, R7>,
     Selector<S8, R8>,
-    Selector<S9, R9>,
+    Selector<S9, R9>
   ]
 >;
 declare function createCachedSelector<
@@ -3653,7 +3742,7 @@ declare function createCachedSelector<
   R7,
   R8,
   R9,
-  T,
+  T
 >(
   selectors: [
     ParametricSelector<S1, P1, R1>,
@@ -3664,7 +3753,7 @@ declare function createCachedSelector<
     ParametricSelector<S6, P6, R6>,
     ParametricSelector<S7, P7, R7>,
     ParametricSelector<S8, P8, R8>,
-    ParametricSelector<S9, P9, R9>,
+    ParametricSelector<S9, P9, R9>
   ],
   combiner: (
     res1: R1,
@@ -3676,7 +3765,8 @@ declare function createCachedSelector<
     res7: R7,
     res8: R8,
     res9: R9
-  ) => T
+  ) => T,
+  createSelectorOptions?: CreateSelectorOptions
 ): OutputParametricCachedSelector<
   S1 & S2 & S3 & S4 & S5 & S6 & S7 & S8 & S9,
   P1 & P2 & P3 & P4 & P5 & P6 & P7 & P8 & P9,
@@ -3701,7 +3791,7 @@ declare function createCachedSelector<
     ParametricSelector<S6, P6, R6>,
     ParametricSelector<S7, P7, R7>,
     ParametricSelector<S8, P8, R8>,
-    ParametricSelector<S9, P9, R9>,
+    ParametricSelector<S9, P9, R9>
   ]
 >;
 
@@ -3727,7 +3817,7 @@ declare function createCachedSelector<
   R8,
   R9,
   R10,
-  T,
+  T
 >(
   selectors: [
     Selector<S1, R1>,
@@ -3739,7 +3829,7 @@ declare function createCachedSelector<
     Selector<S7, R7>,
     Selector<S8, R8>,
     Selector<S9, R9>,
-    Selector<S10, R10>,
+    Selector<S10, R10>
   ],
   combiner: (
     res1: R1,
@@ -3752,7 +3842,8 @@ declare function createCachedSelector<
     res8: R8,
     res9: R9,
     res10: R10
-  ) => T
+  ) => T,
+  createSelectorOptions?: CreateSelectorOptions
 ): OutputCachedSelector<
   S1 & S2 & S3 & S4 & S5 & S6 & S7 & S8 & S9 & S10,
   T,
@@ -3778,7 +3869,7 @@ declare function createCachedSelector<
     Selector<S7, R7>,
     Selector<S8, R8>,
     Selector<S9, R9>,
-    Selector<S10, R10>,
+    Selector<S10, R10>
   ]
 >;
 declare function createCachedSelector<
@@ -3812,7 +3903,7 @@ declare function createCachedSelector<
   R8,
   R9,
   R10,
-  T,
+  T
 >(
   selectors: [
     ParametricSelector<S1, P1, R1>,
@@ -3824,7 +3915,7 @@ declare function createCachedSelector<
     ParametricSelector<S7, P7, R7>,
     ParametricSelector<S8, P8, R8>,
     ParametricSelector<S9, P9, R9>,
-    ParametricSelector<S10, P10, R10>,
+    ParametricSelector<S10, P10, R10>
   ],
   combiner: (
     res1: R1,
@@ -3837,7 +3928,8 @@ declare function createCachedSelector<
     res8: R8,
     res9: R9,
     res10: R10
-  ) => T
+  ) => T,
+  createSelectorOptions?: CreateSelectorOptions
 ): OutputParametricCachedSelector<
   S1 & S2 & S3 & S4 & S5 & S6 & S7 & S8 & S9 & S10,
   P1 & P2 & P3 & P4 & P5 & P6 & P7 & P8 & P9 & P10,
@@ -3864,7 +3956,7 @@ declare function createCachedSelector<
     ParametricSelector<S7, P7, R7>,
     ParametricSelector<S8, P8, R8>,
     ParametricSelector<S9, P9, R9>,
-    ParametricSelector<S10, P10, R10>,
+    ParametricSelector<S10, P10, R10>
   ]
 >;
 
@@ -3892,7 +3984,7 @@ declare function createCachedSelector<
   R9,
   R10,
   R11,
-  T,
+  T
 >(
   selectors: [
     Selector<S1, R1>,
@@ -3905,7 +3997,7 @@ declare function createCachedSelector<
     Selector<S8, R8>,
     Selector<S9, R9>,
     Selector<S10, R10>,
-    Selector<S11, R11>,
+    Selector<S11, R11>
   ],
   combiner: (
     res1: R1,
@@ -3919,7 +4011,8 @@ declare function createCachedSelector<
     res9: R9,
     res10: R10,
     res11: R11
-  ) => T
+  ) => T,
+  createSelectorOptions?: CreateSelectorOptions
 ): OutputCachedSelector<
   S1 & S2 & S3 & S4 & S5 & S6 & S7 & S8 & S9 & S10 & S11,
   T,
@@ -3947,7 +4040,7 @@ declare function createCachedSelector<
     Selector<S8, R8>,
     Selector<S9, R9>,
     Selector<S10, R10>,
-    Selector<S11, R11>,
+    Selector<S11, R11>
   ]
 >;
 declare function createCachedSelector<
@@ -3984,7 +4077,7 @@ declare function createCachedSelector<
   R9,
   R10,
   R11,
-  T,
+  T
 >(
   selectors: [
     ParametricSelector<S1, P1, R1>,
@@ -3997,7 +4090,7 @@ declare function createCachedSelector<
     ParametricSelector<S8, P8, R8>,
     ParametricSelector<S9, P9, R9>,
     ParametricSelector<S10, P10, R10>,
-    ParametricSelector<S11, P11, R11>,
+    ParametricSelector<S11, P11, R11>
   ],
   combiner: (
     res1: R1,
@@ -4011,7 +4104,8 @@ declare function createCachedSelector<
     res9: R9,
     res10: R10,
     res11: R11
-  ) => T
+  ) => T,
+  createSelectorOptions?: CreateSelectorOptions
 ): OutputParametricCachedSelector<
   S1 & S2 & S3 & S4 & S5 & S6 & S7 & S8 & S9 & S10 & S11,
   P1 & P2 & P3 & P4 & P5 & P6 & P7 & P8 & P9 & P10 & P11,
@@ -4040,7 +4134,7 @@ declare function createCachedSelector<
     ParametricSelector<S8, P8, R8>,
     ParametricSelector<S9, P9, R9>,
     ParametricSelector<S10, P10, R10>,
-    ParametricSelector<S11, P11, R11>,
+    ParametricSelector<S11, P11, R11>
   ]
 >;
 
@@ -4070,7 +4164,7 @@ declare function createCachedSelector<
   R10,
   R11,
   R12,
-  T,
+  T
 >(
   selectors: [
     Selector<S1, R1>,
@@ -4084,7 +4178,7 @@ declare function createCachedSelector<
     Selector<S9, R9>,
     Selector<S10, R10>,
     Selector<S11, R11>,
-    Selector<S12, R12>,
+    Selector<S12, R12>
   ],
   combiner: (
     res1: R1,
@@ -4099,7 +4193,8 @@ declare function createCachedSelector<
     res10: R10,
     res11: R11,
     res12: R12
-  ) => T
+  ) => T,
+  createSelectorOptions?: CreateSelectorOptions
 ): OutputCachedSelector<
   S1 & S2 & S3 & S4 & S5 & S6 & S7 & S8 & S9 & S10 & S11 & S12,
   T,
@@ -4129,7 +4224,7 @@ declare function createCachedSelector<
     Selector<S9, R9>,
     Selector<S10, R10>,
     Selector<S11, R11>,
-    Selector<S12, R12>,
+    Selector<S12, R12>
   ]
 >;
 declare function createCachedSelector<
@@ -4169,7 +4264,7 @@ declare function createCachedSelector<
   R10,
   R11,
   R12,
-  T,
+  T
 >(
   selectors: [
     ParametricSelector<S1, P1, R1>,
@@ -4183,7 +4278,7 @@ declare function createCachedSelector<
     ParametricSelector<S9, P9, R9>,
     ParametricSelector<S10, P10, R10>,
     ParametricSelector<S11, P11, R11>,
-    ParametricSelector<S12, P12, R12>,
+    ParametricSelector<S12, P12, R12>
   ],
   combiner: (
     res1: R1,
@@ -4198,7 +4293,8 @@ declare function createCachedSelector<
     res10: R10,
     res11: R11,
     res12: R12
-  ) => T
+  ) => T,
+  createSelectorOptions?: CreateSelectorOptions
 ): OutputParametricCachedSelector<
   S1 & S2 & S3 & S4 & S5 & S6 & S7 & S8 & S9 & S10 & S11 & S12,
   P1 & P2 & P3 & P4 & P5 & P6 & P7 & P8 & P9 & P10 & P11 & P12,
@@ -4229,7 +4325,7 @@ declare function createCachedSelector<
     ParametricSelector<S9, P9, R9>,
     ParametricSelector<S10, P10, R10>,
     ParametricSelector<S11, P11, R11>,
-    ParametricSelector<S12, P12, R12>,
+    ParametricSelector<S12, P12, R12>
   ]
 >;
 
@@ -4238,11 +4334,13 @@ declare function createCachedSelector<
  */
 declare function createCachedSelector<S, R, T>(
   selectors: Selector<S, R>[],
-  combiner: (...res: R[]) => T
+  combiner: (...res: R[]) => T,
+  createSelectorOptions?: CreateSelectorOptions
 ): OutputCachedSelector<S, T, (...res: R[]) => T, Selector<S, R>[]>;
 declare function createCachedSelector<S, P, R, T>(
   selectors: ParametricSelector<S, P, R>[],
-  combiner: (...res: R[]) => T
+  combiner: (...res: R[]) => T,
+  createSelectorOptions?: CreateSelectorOptions
 ): OutputParametricCachedSelector<
   S,
   P,
@@ -4260,7 +4358,7 @@ export {createCachedSelector};
 export function createStructuredCachedSelector<
   T extends {[key: string]: (state: any) => any},
   S = $Values<{[K in keyof T]: Parameters<T[K]>[0]}>,
-  R = {[K in keyof T]: ReturnType<T[K]>},
+  R = {[K in keyof T]: ReturnType<T[K]>}
 >(
   selectors: T
 ): OutputCachedSelector<
@@ -4276,7 +4374,7 @@ export function createStructuredCachedSelector<
   },
   S = $Values<{[K in keyof T]: Parameters<T[K]>[0]}>,
   P = Exclude<$Values<{[K in keyof T]: Parameters<T[K]>[1]}>, undefined>,
-  R = {[K in keyof T]: ReturnType<T[K]>},
+  R = {[K in keyof T]: ReturnType<T[K]>}
 >(
   selectors: T
 ): OutputParametricCachedSelector<

--- a/src/typescript_tests/createCachedSelector.ts
+++ b/src/typescript_tests/createCachedSelector.ts
@@ -421,3 +421,20 @@ function testSelectorCreatorOptionNonLruMemoize() {
     selectorCreator: createSelectorCreator(func => func),
   });
 }
+
+function testReselectOptionObject() {
+  type State = {foo: string};
+
+  createCachedSelector(
+    (state: {foo: string}) => state.foo,
+    (state: {bar: number}) => state.bar,
+    (foo, bar) => 1,
+    {memoizeOptions: {resultEqualityCheck: () => true}}
+  )((state: State) => state.foo);
+
+  createCachedSelector(
+    [(state: {foo: string}) => state.foo, (state: {bar: number}) => state.bar],
+    (foo, bar) => 1,
+    {memoizeOptions: {resultEqualityCheck: () => true}}
+  )((state: State) => state.foo);
+}


### PR DESCRIPTION
### What kind of change does this PR introduce? _(Bug fix, feature, docs update, ...)_

Feature

### What is the current behaviour? _(You can also link to an open issue here)_

#228 

### What is the new behaviour?

`createCachedSelector` supports `reselect`'s `createSelectorOptions` option.

### Does this PR introduce a breaking change? _(What changes might users need to make in their application due to this PR?)_

No

### Other information:

### Please check if the PR fulfills these requirements:

- [X] Tests for the changes have been added
- [ ] Docs have been added / updated
