### PR TITLE
fix: type error when createStructuredCachedSelector selector has optional argument

### DIFF
--- a/.changeset/fix-structured-optional-argument.md
+++ b/.changeset/fix-structured-optional-argument.md
@@ -1,0 +1,5 @@
+---
+'re-reselect': patch
+---
+
+Fix `createStructuredCachedSelector` type error when a selector has an optional argument

--- a/.changeset/fix-structured-optional-argument.md
+++ b/.changeset/fix-structured-optional-argument.md
@@ -2,4 +2,4 @@
 're-reselect': patch
 ---
 
-Fix `createStructuredCachedSelector` type error when a selector has an optional argument
+Fix `createStructuredCachedSelector` type error when a selector has a second optional argument

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -8,6 +8,40 @@ export type ParametricSelector<S, P, R> = (
   props: P,
   ...args: any[]
 ) => R;
+export type OptionalParametricSelector<S, P, R> = (
+  state: S,
+  props?: P,
+  ...args: any[]
+) => R;
+
+// Structured selector helpers: detect whether the provided selectors expect
+// a second (props) argument and, if so, whether that argument is required.
+type StructuredHasSecondParam<F extends (...args: any[]) => any> =
+  Parameters<F> extends [any, ...infer Rest]
+    ? Rest extends []
+      ? false
+      : true
+    : false;
+
+type StructuredIsParametric<
+  T extends { [key: string]: (...args: any[]) => any },
+> =
+  true extends $Values<{
+    [K in keyof T]: StructuredHasSecondParam<T[K]>;
+  }>
+    ? true
+    : false;
+
+// `false` here means "callable with a single argument", so a `false` in the
+// union signals that at least one selector requires the props argument.
+type StructuredHasRequiredProps<
+  T extends { [key: string]: (...args: any[]) => any },
+> =
+  false extends $Values<{
+    [K in keyof T]: 1 extends Parameters<T[K]>['length'] ? true : false;
+  }>
+    ? true
+    : false;
 
 export type KeySelector<S> = (state: S, ...args: any[]) => any;
 export type ParametricKeySelector<S, P> = (
@@ -32,6 +66,13 @@ export type OutputParametricSelector<S, P, R, C, D> = ParametricSelector<
   recomputations: () => number;
   resetRecomputations: () => number;
 };
+export type OutputOptionalParametricSelector<S, P, R, C, D> =
+  OptionalParametricSelector<S, P, R> & {
+    resultFunc: C;
+    dependencies: D;
+    recomputations: () => number;
+    resetRecomputations: () => number;
+  };
 
 export type CreateSelectorInstance = Omit<typeof createSelector, 'clearCache'>;
 
@@ -68,6 +109,20 @@ export type OutputParametricCachedSelector<S, P, R, C, D> = (
     ...args: any[]
   ) => OutputParametricSelector<S, P, R, C, D>;
   removeMatchingSelector: (state: S, props: P, ...args: any[]) => void;
+  clearCache: () => void;
+  cache: ICacheObject;
+  keySelector: ParametricKeySelector<S, P>;
+};
+
+export type OutputOptionalParametricCachedSelector<S, P, R, C, D> = (
+  options: ParametricKeySelector<S, P> | ParametricOptions<S, P, C, D>,
+) => OutputOptionalParametricSelector<S, P, R, C, D> & {
+  getMatchingSelector: (
+    state: S,
+    props?: P,
+    ...args: any[]
+  ) => OutputOptionalParametricSelector<S, P, R, C, D>;
+  removeMatchingSelector: (state: S, props?: P, ...args: any[]) => void;
   clearCache: () => void;
   cache: ICacheObject;
   keySelector: ParametricKeySelector<S, P>;
@@ -4357,34 +4412,36 @@ export { createCachedSelector };
  */
 
 export function createStructuredCachedSelector<
-  T extends { [key: string]: (state: any) => any },
-  S = $Values<{ [K in keyof T]: Parameters<T[K]>[0] }>,
-  R = { [K in keyof T]: ReturnType<T[K]> },
->(
-  selectors: T,
-): OutputCachedSelector<
-  S,
-  R,
-  (...args: $Values<R>[]) => R,
-  Selector<S, $Values<R>>[]
->;
-
-export function createStructuredCachedSelector<
   T extends {
-    [key: string]: (state: any, props: any, ...args: any[]) => any;
+    [key: string]: (state: any, ...args: any[]) => any;
   },
   S = $Values<{ [K in keyof T]: Parameters<T[K]>[0] }>,
   P = Exclude<$Values<{ [K in keyof T]: Parameters<T[K]>[1] }>, undefined>,
   R = { [K in keyof T]: ReturnType<T[K]> },
 >(
   selectors: T,
-): OutputParametricCachedSelector<
-  S,
-  P,
-  R,
-  (...args: $Values<R>[]) => R,
-  ParametricSelector<S, P, $Values<R>>[]
->;
+): StructuredIsParametric<T> extends false
+  ? OutputCachedSelector<
+      S,
+      R,
+      (...args: $Values<R>[]) => R,
+      Selector<S, $Values<R>>[]
+    >
+  : StructuredHasRequiredProps<T> extends true
+    ? OutputParametricCachedSelector<
+        S,
+        P,
+        R,
+        (...args: $Values<R>[]) => R,
+        ParametricSelector<S, P, $Values<R>>[]
+      >
+    : OutputOptionalParametricCachedSelector<
+        S,
+        P,
+        R,
+        (...args: $Values<R>[]) => R,
+        ParametricSelector<S, P, $Values<R>>[]
+      >;
 
 /*
  * Cache objects

--- a/test/createStructuredCachedSelector.test.ts
+++ b/test/createStructuredCachedSelector.test.ts
@@ -107,6 +107,28 @@ describe('createStructuredCachedSelector', () => {
         >();
         expectTypeOf(selector2).returns.toEqualTypeOf<Result>();
 
+        // 1.3 One selector has an *optional* second param.
+        // See https://github.com/toomuchdesign/re-reselect/issues/155
+        // The resulting selector must accept the props argument as optional:
+        // both `selector3(state)` and `selector3(state, id)` must type-check.
+        const mySelectorE = (state: State) => state.a;
+        const mySelectorF = (state: State, id?: string) =>
+          id ? state.items[id] : state.a;
+        const selector3 = createStructuredCachedSelector({
+          x: mySelectorE,
+          y: mySelectorF,
+        })((state, id?: string) => id ?? '');
+
+        const state: State = { a: 'foo', items: { id1: 'bar' } };
+        // Both call signatures must be valid (this is the actual bug repro).
+        expectTypeOf(selector3(state)).toEqualTypeOf<Result>();
+        expectTypeOf(selector3(state, 'id1')).toEqualTypeOf<Result>();
+
+        expectTypeOf(selector3).parameters.toEqualTypeOf<
+          [State, (string | undefined)?, ...any[]]
+        >();
+        expectTypeOf(selector3).returns.toEqualTypeOf<Result>();
+
         // 2. Explicitly set State and Parameter types for all selector functions
         // => not supported
       });


### PR DESCRIPTION
### What kind of change does this PR introduce? _(Bug fix, feature, docs update, ...)_

Bug fix (TypeScript types).

### What is the current behaviour? _(You can also link to an open issue here)_

Closes #155.

When a `createStructuredCachedSelector` is built from selectors whose second
(props) argument is **optional**, TypeScript rejects calling the resulting
selector with that argument:

```ts
const itemCountSelector = createStructuredCachedSelector({
  allItemCounts: (state: State) => state,
  // Notice that the second argument is optional
  singleItemCount: (state: State, itemId?: string) =>
    itemId ? state.itemCounts[itemId] : null,
})((_state, itemId?: string) => itemId);

itemCountSelector(state);          // ok
itemCountSelector(state, 'item1'); // ❌ TS2554: Expected 1 arguments, but got 2
```

Root cause: `createStructuredCachedSelector` exposed two overloads, the first
of which was non-parametric (`{ [key: string]: (state: any) => any }`). A
function with an *optional* second argument is assignable to a single-argument
signature, so that first overload matched and produced an output selector
accepting only `state` — hence the error when the optional argument is passed.

### What is the new behaviour?

The two overloads are replaced by a single signature with a conditional return
type that distinguishes three cases:

- **non-parametric** – no selector takes a second argument → `OutputCachedSelector`;
- **required props** – at least one selector requires a second argument →
  `OutputParametricCachedSelector` (unchanged behaviour);
- **optional props** – selectors only accept an *optional* second argument →
  new `OutputOptionalParametricCachedSelector`, whose `props` argument stays
  optional.

As a result both `itemCountSelector(state)` and `itemCountSelector(state, 'item1')`
type-check. Existing non-parametric and required-props behaviour is preserved.

### Does this PR introduce a breaking change? _(What changes might users need to make in their application due to this PR?)_

No. This only relaxes the types for the previously-erroring optional-argument
case; non-parametric and required-argument selectors keep their existing
signatures.

### Other information:

- Type-level change only (`src/index.d.ts`); no runtime code is touched.
- A type test reproducing the issue was added to
  `test/createStructuredCachedSelector.test.ts` (case `1.3`), asserting that
  both call signatures are valid and that the resulting parameters are
  `[State, (string | undefined)?, ...any[]]`.
- `npm run type:check` passes and the full suite is green (18 files, 113 tests,
  no type errors).

### Please check if the PR fulfills these requirements:

- [x] Tests for the changes have been added
- [ ] Docs have been added / updated
