### PR TITLE
ci: change release npm installation to version 11

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,7 +32,7 @@ jobs:
           node-version-file: .nvmrc
 
         # Ensure npm 11.5.1 or later is installed
-      - run: npm install -g npm@latest
+      - run: npm install -g npm@11
       - run: npm ci --ignore-scripts
 
       - name: Create Release PR or Publish to npm


### PR DESCRIPTION
### What kind of change does this PR introduce? _(Bug fix, feature, docs update, ...)_

Fix release job.

### What is the current behaviour? _(You can also link to an open issue here)_

Release job failing with:

```
Run npm install -g npm@latest
  npm install -g npm@latest
  shell: /usr/bin/bash -e {0}
npm error code EBADENGINE
npm error engine Unsupported engine
npm error engine Not compatible with your version of node/npm: npm@12.0.1
npm error notsup Not compatible with your version of node/npm: npm@12.0.1
npm error notsup Required: {"node":"^22.22.2 || ^24.15.0 || >=26.0.0"}
npm error notsup Actual:   {"npm":"10.8.2","node":"v20.19.6"}
```

### What is the new behaviour?

Install latest npm v11

### Does this PR introduce a breaking change? _(What changes might users need to make in their application due to this PR?)_

No

### Other information:

### Please check if the PR fulfills these requirements:

- [ ] Tests for the changes have been added
- [ ] Docs have been added / updated
